### PR TITLE
Add faster-whisper IPA transcription prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,61 @@
   - Providing confidence scoring and diagnostics for linguists or downstream systems.
 - **Primary users:** Linguists documenting languages, accessibility applications, speech researchers, and creative tools (e.g., voice acting or synthetic speech systems).
 
+## Quick Prototype: Faster-Whisper + IPA Conversion
+
+The repository now includes a small Python package that wires together
+[faster-whisper](https://github.com/guillaumekln/faster-whisper) for rapid speech
+recognition and [`phonemizer`](https://github.com/bootphon/phonemizer) with the
+`espeak-ng` backend for text-to-IPA conversion. It is intentionally lightweight
+so that we can iterate quickly before worrying about large-scale feedback or UI
+polish.
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+# system dependencies (Ubuntu/Debian examples)
+sudo apt-get update && sudo apt-get install -y ffmpeg espeak-ng
+```
+
+- **FFmpeg** is required so faster-whisper can decode common audio formats.
+- **espeak-ng** powers the IPA conversion inside `phonemizer`. If you are on
+  macOS use `brew install ffmpeg espeak` instead.
+
+### Usage
+
+```bash
+python -m speechtoipa.cli path/to/audio.wav --model small --segments
+```
+
+The command prints the transcript, IPA rendering, and (optionally) each segment
+with timestamps. Use `--output result.json` to capture structured output.
+
+Key options:
+
+| Flag | Purpose |
+| ---- | ------- |
+| `--model` | Pick any faster-whisper checkpoint (`tiny`, `base`, `small`, etc.). |
+| `--language` | Hint Whisper if you already know the language. |
+| `--ipa-language` | Force a specific espeak-ng code (defaults to detected language). |
+| `--device` / `--compute-type` | Switch to GPU or float precision manually. |
+| `--disable-vad` | Skip the built-in voice-activity detector. |
+| `--segments` | Print per-segment IPA output for review. |
+
+The JSON payload written with `--output` includes per-segment timings, IPA, and
+model metadata so downstream tooling can consume it easily.
+
+### What’s next?
+
+- Swap in distilled checkpoints or quantised CTranslate2 models for embedded
+  devices.
+- Support streaming input and diarisation once we graduate from this CLI.
+- Layer in richer post-processing (tone marks, articulatory features) once we
+  have feedback on the IPA accuracy across multiple languages.
+
 ## End-to-End Processing Pipeline
 1. **Ingestion & Normalization**
    - Accept streaming (WebRTC/microphone) and batch (upload) audio.

--- a/index.html
+++ b/index.html
@@ -1,1 +1,83 @@
-
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Speech-to-IPA Prototype</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        padding: 3rem 1.5rem;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+        background: rgba(15, 23, 42, 0.85);
+        padding: 2.5rem;
+        border-radius: 24px;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.65);
+      }
+      h1 {
+        margin-top: 0;
+        font-size: 2.75rem;
+        line-height: 1.1;
+        color: #38bdf8;
+      }
+      p {
+        line-height: 1.6;
+      }
+      code {
+        background: rgba(226, 232, 240, 0.08);
+        padding: 0.15rem 0.35rem;
+        border-radius: 6px;
+        font-size: 0.95rem;
+      }
+      pre {
+        background: rgba(226, 232, 240, 0.08);
+        padding: 1rem;
+        border-radius: 12px;
+        overflow-x: auto;
+      }
+      a {
+        color: #f472b6;
+      }
+      ul {
+        padding-left: 1.1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Speech-to-IPA Prototype</h1>
+      <p>
+        This project is an experimental pipeline that stitches together
+        <a href="https://github.com/guillaumekln/faster-whisper">faster-whisper</a>
+        for multilingual transcription with the
+        <a href="https://github.com/bootphon/phonemizer">phonemizer</a>
+        toolkit (using <code>espeak-ng</code>) to emit IPA symbols. The current
+        focus is on iterating quickly, validating IPA quality, and preparing for
+        richer UI/feedback loops.
+      </p>
+      <p>
+        Start by installing the Python dependencies and system packages, then run
+        the CLI against any FFmpeg-compatible audio file:
+      </p>
+      <pre><code>python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+sudo apt-get install ffmpeg espeak-ng
+python -m speechtoipa.cli example.wav --segments</code></pre>
+      <p>
+        The CLI outputs JSON (with <code>--output</code>) and human-readable
+        summaries so we can plug it into future web or research workflows.
+      </p>
+      <p>
+        Up next: streaming transcription, diarisation, richer suprasegmental
+        modelling, and feedback capture tooling.
+      </p>
+    </main>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+faster-whisper>=0.10.0,<1.0.0
+phonemizer>=3.2,<4.0
+soundfile>=0.12,<0.13

--- a/speechtoipa/__init__.py
+++ b/speechtoipa/__init__.py
@@ -1,0 +1,5 @@
+"""Speech-to-IPA prototype package."""
+
+__all__ = ["transcribe_audio_to_ipa", "TranscriptionResult", "SegmentResult"]
+
+from .pipeline import transcribe_audio_to_ipa, TranscriptionResult, SegmentResult

--- a/speechtoipa/cli.py
+++ b/speechtoipa/cli.py
@@ -1,0 +1,125 @@
+"""Command-line interface for the speech-to-IPA prototype."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .pipeline import TranscriptionResult, transcribe_audio_to_ipa
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Transcribe an audio file with faster-whisper and convert the transcript to IPA using espeak-ng."
+        )
+    )
+    parser.add_argument("audio", type=Path, help="Path to the input audio file (any ffmpeg-compatible format).")
+    parser.add_argument(
+        "--model",
+        default="small",
+        help="Whisper model size to download/use (tiny, base, small, medium, large-v2, etc.).",
+    )
+    parser.add_argument(
+        "--language",
+        help="Override language detection by providing a two-letter language hint understood by Whisper.",
+    )
+    parser.add_argument(
+        "--ipa-language",
+        help="Override the espeak-ng language code used for phonemization (defaults to the detected language).",
+    )
+    parser.add_argument(
+        "--device",
+        default="cpu",
+        choices=["cpu", "cuda"],
+        help="Device to run inference on. Use 'cuda' for NVIDIA GPUs if available.",
+    )
+    parser.add_argument(
+        "--compute-type",
+        help="Override faster-whisper compute type (e.g. int8, float16, float32). Auto-selected by default.",
+    )
+    parser.add_argument(
+        "--disable-vad",
+        action="store_true",
+        help="Disable the built-in voice-activity detector (keep long silences).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the transcription result as JSON (UTF-8).",
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Do not use ANSI colors in the terminal summary output.",
+    )
+    parser.add_argument(
+        "--segments",
+        action="store_true",
+        help="Print each segment with timestamps alongside the aggregate IPA transcript.",
+    )
+    return parser
+
+
+def _format_summary(result: TranscriptionResult, *, color: bool, segments: bool) -> str:
+    def style(text: str, code: str) -> str:
+        if not color:
+            return text
+        return f"\033[{code}m{text}\033[0m"
+
+    if result.language_confidence is None:
+        confidence_str = "n/a"
+    else:
+        confidence_str = f"{result.language_confidence:.3f}"
+
+    lines = [
+        style("Speech-to-IPA prototype", "1;36"),
+        f"Audio: {result.audio_path}",
+        f"Model: {result.model_size}",
+        f"Detected language: {result.language or 'unknown'} (confidence={confidence_str})",
+        f"IPA backend language: {result.ipa_language}",
+        f"Duration: {result.duration:.2f}s" if result.duration is not None else "Duration: n/a",
+        "",
+        style("Transcript:", "1;37"),
+        result.text or "<empty>",
+        "",
+        style("IPA:", "1;37"),
+        result.ipa or "<empty>",
+    ]
+
+    if segments and result.segments:
+        lines.append("")
+        lines.append(style("Segments:", "1;37"))
+        for seg in result.segments:
+            lines.append(
+                f"[{seg.start:6.2f}s – {seg.end:6.2f}s] {seg.text}\n    {style(seg.ipa, '36')}"
+            )
+
+    return "\n".join(lines)
+
+
+def run_cli(argv: Optional[Iterable[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    result = transcribe_audio_to_ipa(
+        args.audio,
+        model_size=args.model,
+        language=args.language,
+        ipa_language=args.ipa_language,
+        device=args.device,
+        compute_type=args.compute_type,
+        vad_filter=not args.disable_vad,
+    )
+
+    if args.output:
+        args.output.write_text(result.to_json(indent=2), encoding="utf-8")
+
+    summary = _format_summary(result, color=not args.no_color, segments=args.segments)
+    print(summary)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli())

--- a/speechtoipa/pipeline.py
+++ b/speechtoipa/pipeline.py
@@ -1,0 +1,218 @@
+"""Core transcription pipeline for converting speech audio to IPA."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import List, Optional
+
+from faster_whisper import WhisperModel
+from phonemizer import phonemize
+
+__all__ = [
+    "SegmentResult",
+    "TranscriptionResult",
+    "transcribe_audio_to_ipa",
+]
+
+# Minimal mapping between Whisper language hints and espeak-ng codes.
+_ESPEAK_LANG_MAP = {
+    "af": "af",
+    "ar": "ar",
+    "bn": "bn",
+    "cs": "cs",
+    "da": "da",
+    "de": "de",
+    "el": "el",
+    "en": "en-us",
+    "en-us": "en-us",
+    "en-gb": "en-gb",
+    "es": "es",
+    "fi": "fi",
+    "fr": "fr-fr",
+    "gu": "gu",
+    "hi": "hi",
+    "hu": "hu",
+    "id": "id",
+    "it": "it",
+    "ja": "ja",
+    "ko": "ko",
+    "mr": "mr",
+    "nb": "nb",
+    "nl": "nl",
+    "pl": "pl",
+    "pt": "pt-br",
+    "pt-br": "pt-br",
+    "pt-pt": "pt",
+    "ro": "ro",
+    "ru": "ru",
+    "sv": "sv",
+    "ta": "ta",
+    "te": "te",
+    "th": "th",
+    "tr": "tr",
+    "uk": "uk",
+    "ur": "ur",
+    "vi": "vi",
+    "zh": "zh",
+    "zh-cn": "zh",
+    "zh-tw": "zh",
+}
+
+_PUNCTUATION = ";:,.!?¡¿—…\"«»“”()[]{}"
+
+
+def _normalise_lang_code(code: Optional[str]) -> Optional[str]:
+    if code is None:
+        return None
+    return code.lower().strip().replace("_", "-")
+
+
+def _resolve_espeak_language(language_hint: Optional[str]) -> str:
+    """Map Whisper language hints to espeak-ng language codes."""
+    if not language_hint:
+        return "en-us"
+
+    normalised = _normalise_lang_code(language_hint)
+    if not normalised:
+        return "en-us"
+
+    if normalised in _ESPEAK_LANG_MAP:
+        return _ESPEAK_LANG_MAP[normalised]
+
+    # Try stripping regional subtags (e.g., "pt-br" -> "pt").
+    if "-" in normalised:
+        base = normalised.split("-", 1)[0]
+        if base in _ESPEAK_LANG_MAP:
+            return _ESPEAK_LANG_MAP[base]
+
+    # Fall back to the normalised hint itself. espeak-ng is permissive with many aliases.
+    return normalised
+
+
+@dataclass
+class SegmentResult:
+    """Stores the timing, recognised text, and IPA for a single segment."""
+
+    start: float
+    end: float
+    text: str
+    ipa: str
+    avg_logprob: Optional[float] = None
+    no_speech_prob: Optional[float] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class TranscriptionResult:
+    """Complete transcription result including segments and metadata."""
+
+    audio_path: Path
+    text: str
+    ipa: str
+    segments: List[SegmentResult]
+    language: str
+    language_confidence: Optional[float]
+    duration: Optional[float]
+    model_size: str
+    ipa_language: str
+
+    def to_dict(self) -> dict:
+        payload = asdict(self)
+        payload["audio_path"] = str(self.audio_path)
+        payload["segments"] = [segment.to_dict() for segment in self.segments]
+        return payload
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
+
+
+def _phonemize_text(text: str, ipa_language: str) -> str:
+    if not text.strip():
+        return ""
+
+    try:
+        return phonemize(
+            text,
+            language=ipa_language,
+            backend="espeak",
+            strip=True,
+            preserve_punctuation=True,
+            with_stress=True,
+            punctuation_marks=_PUNCTUATION,
+        )
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "Failed to phonemize text. Ensure espeak-ng is installed and the language "
+            f"'{ipa_language}' is supported."
+        ) from exc
+
+
+def transcribe_audio_to_ipa(
+    audio_path: Path | str,
+    *,
+    model_size: str = "small",
+    language: Optional[str] = None,
+    ipa_language: Optional[str] = None,
+    device: str = "cpu",
+    compute_type: Optional[str] = None,
+    vad_filter: bool = True,
+) -> TranscriptionResult:
+    """Transcribes ``audio_path`` and returns IPA-rich metadata."""
+
+    resolved_audio_path = Path(audio_path)
+    if not resolved_audio_path.exists():
+        raise FileNotFoundError(f"Audio file not found: {resolved_audio_path}")
+
+    if compute_type is None:
+        compute_type = "int8" if device == "cpu" else "auto"
+
+    model = WhisperModel(model_size, device=device, compute_type=compute_type)
+    segments_iter, info = model.transcribe(
+        str(resolved_audio_path),
+        language=language,
+        beam_size=1,
+        best_of=1,
+        vad_filter=vad_filter,
+        temperature=0.0,
+    )
+
+    recognised_language = language or info.language or ""
+    ipa_code = ipa_language or _resolve_espeak_language(recognised_language)
+
+    segments: List[SegmentResult] = []
+    full_text_parts: List[str] = []
+
+    for segment in segments_iter:
+        segment_text = segment.text.strip()
+        if not segment_text:
+            continue
+        full_text_parts.append(segment_text)
+        segment_ipa = _phonemize_text(segment_text, ipa_code)
+        segments.append(
+            SegmentResult(
+                start=segment.start,
+                end=segment.end,
+                text=segment_text,
+                ipa=segment_ipa,
+                avg_logprob=getattr(segment, "avg_logprob", None),
+                no_speech_prob=getattr(segment, "no_speech_prob", None),
+            )
+        )
+
+    full_text = " ".join(full_text_parts).strip()
+    full_ipa = _phonemize_text(full_text, ipa_code) if full_text else ""
+
+    return TranscriptionResult(
+        audio_path=resolved_audio_path,
+        text=full_text,
+        ipa=full_ipa,
+        segments=segments,
+        language=recognised_language,
+        language_confidence=getattr(info, "language_probability", None),
+        duration=getattr(info, "duration", None),
+        model_size=model_size,
+        ipa_language=ipa_code,
+    )


### PR DESCRIPTION
## Summary
- add a small Python package that runs faster-whisper and phonemizer to produce IPA transcripts
- provide a CLI entry point, requirements, and lightweight landing page copy
- document installation and usage instructions in the README

## Testing
- python -m compileall speechtoipa

------
https://chatgpt.com/codex/tasks/task_e_68d3b45f15d483338fa856ba144f93bf