### PR TITLE
Add Opera mobile cache troubleshooting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Key options:
 The JSON payload written with `--output` includes per-segment timings, IPA, and
 model metadata so downstream tooling can consume it easily.
 
+### Troubleshooting
+
+- **Mobile browser cache (Opera):** If the web demo fails to load in Opera for
+  Android/iOS even though other browsers work, clear the browser cache and
+  reload. Opera has been observed to hold on to stale service worker assets,
+  preventing the engine from initialising until the cache is reset.
+
 ### What’s next?
 
 - Swap in distilled checkpoints or quantised CTranslate2 models for embedded


### PR DESCRIPTION
## Summary
- add a troubleshooting section to the README
- document the Opera mobile browser cache-clearing workaround

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d64f6bde188333a77f58ca02429e2e