### PR TITLE
Add offline transcription server and MediaRecorder workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,54 @@
 # Reading Pronunciation Practice
 
-An interactive web exercise that helps students practice reading aloud. Pick a
-paragraph, listen to the model reader, then record yourself. The site captures
-your microphone audio with the browser's Speech Recognition API, compares the
-recognized transcript against the source text, and colours each word green or
-red to highlight potential pronunciation slips.
+An interactive web exercise that helps students practise reading aloud. Pick a
+paragraph, listen to the model reader, then record yourself. A bundled local
+server transcribes the raw audio with [faster-whisper](https://github.com/guillaumekln/faster-whisper)
+and produces IPA strings via `phonemizer` + `espeak-ng`, all without relying on
+any external cloud APIs. The recognised transcript is compared against the
+source text and each word is coloured green or red to highlight potential
+pronunciation slips.
 
 ## Features
 - Curated paragraph bank with approachable, imagery-rich sentences.
 - One-click text-to-speech playback using the Web Speech synthesis engine.
-- Microphone-powered practice session with live feedback after each attempt.
+- Microphone-powered practice session with feedback after each attempt.
 - Word-by-word highlighting to make it easy to spot tricky phrases.
-- Works entirely in the browser—no accounts, servers, or external services.
+- Works entirely on your machine—no accounts or external services required.
+- FastAPI-powered local inference endpoint so the browser can stay offline.
 
 ## Getting Started
-1. Open `index.html` in a modern Chromium-based browser (Chrome, Edge, Brave).
-2. Choose a paragraph from the dropdown.
-3. Press **Play model reading** to hear the reference pronunciation.
-4. When you're ready, press **Start practice** and read the paragraph aloud.
+1. Install the Python dependencies and speech engine:
+   ```bash
+   pip install -r requirements.txt
+   # On Debian/Ubuntu
+   sudo apt-get install espeak-ng
+   ```
+   The first transcription will automatically download the requested
+   faster-whisper model (default: `small`) into your local cache. To control the
+   location, set `FWHISPER_ASSET_DIR` before running the server.
+2. Launch the offline inference endpoint:
+   ```bash
+   python -m speechtoipa.local_server --host 127.0.0.1 --port 8000 --model-size small
+   ```
+   Use `--device cuda` and an appropriate `--compute-type` if you have a GPU.
+   The server also serves `index.html`, so you can point your browser straight
+   at `http://127.0.0.1:8000/`.
+3. Choose a paragraph from the dropdown and press **Play model reading** to hear
+   the reference pronunciation.
+4. When you're ready, press **Start practice**. Your microphone audio is
+   recorded locally, converted to WAV in the browser, and sent to the local
+   server for transcription.
 5. Review the transcript and colour-coded feedback, then repeat as needed.
-
-> **Note:** Speech recognition currently works best in desktop Chrome. Other
-> browsers may not expose the necessary APIs or may require enabling
-> experimental flags.
 
 ## How it Works
 - **Speech synthesis:** The Web Speech API (`speechSynthesis`) reads the
   paragraph at a slightly reduced pace to encourage mindful listening.
-- **Speech recognition:** `SpeechRecognition`/`webkitSpeechRecognition`
-  listens through the microphone and returns a transcript once you finish.
+- **Speech recognition:** The browser captures raw audio with the
+  `MediaRecorder` API, converts it to WAV, and posts the data to the local
+  FastAPI endpoint.
+- **Transcription & phonemisation:** The Python server feeds the audio into
+  `speechtoipa.pipeline.transcribe_audio_to_ipa`, which uses faster-whisper to
+  recognise text and `espeak-ng` (via `phonemizer`) to derive IPA strings.
 - **Comparison:** The transcript is normalised (lowercased, punctuation
   removed) and compared token by token to the source paragraph. Matching words
   are marked green; mismatches remain red so students can focus on improvement.
@@ -42,7 +62,8 @@ red to highlight potential pronunciation slips.
   backend if you need instructor dashboards.
 
 ## Accessibility & Privacy
-- All interactions happen locally in the browser. No audio leaves the device.
+- Audio never leaves your machine; it only flows between the browser and the
+  locally running FastAPI server.
 - Buttons include emoji cues and large tap targets for touch users.
 - ARIA live regions announce updates so screen readers stay informed.
 

--- a/index.html
+++ b/index.html
@@ -211,6 +211,7 @@
       <section id="status" class="status">
         <p id="supportMessage" class="hidden"></p>
         <p class="hidden" id="listening">Listening… speak clearly into your microphone.</p>
+        <p class="hidden" id="processing">Processing recording…</p>
         <div class="hidden" id="result">
           <strong>Recognised transcript</strong>
           <div class="transcript" id="transcript">—</div>
@@ -225,6 +226,7 @@
       const startButton = document.getElementById("start");
       const stopButton = document.getElementById("stop");
       const listeningLabel = document.getElementById("listening");
+      const processingLabel = document.getElementById("processing");
       const resultContainer = document.getElementById("result");
       const transcriptEl = document.getElementById("transcript");
       const supportMessage = document.getElementById("supportMessage");
@@ -251,8 +253,15 @@
       ];
 
       const synth = window.speechSynthesis;
-      let recognition;
       let isListening = false;
+      let isProcessing = false;
+      let mediaRecorder = null;
+      let recordedChunks = [];
+      let activeStream = null;
+      let audioContext = null;
+      let activeParagraphId = null;
+
+      const API_ENDPOINT = "/api/transcribe";
 
       function populateParagraphs() {
         PARAGRAPHS.forEach((p, index) => {
@@ -262,6 +271,7 @@
           if (index === 0) option.selected = true;
           paragraphSelect.append(option);
         });
+        activeParagraphId = PARAGRAPHS[0].id;
         renderParagraph(PARAGRAPHS[0].text);
       }
 
@@ -298,7 +308,9 @@
       }
 
       function speakParagraph() {
-        const { text } = getSelectedParagraph();
+        const selectedParagraph = getSelectedParagraph();
+        activeParagraphId = selectedParagraph.id;
+        const { text } = selectedParagraph;
         if (!("speechSynthesis" in window)) {
           supportMessage.textContent =
             "Speech synthesis is not supported in this browser.";
@@ -311,53 +323,6 @@
         utterance.pitch = 1;
         utterance.lang = "en-US";
         synth.speak(utterance);
-      }
-
-      function ensureRecognition() {
-        if (recognition) return recognition;
-        const SpeechRecognition =
-          window.SpeechRecognition || window.webkitSpeechRecognition;
-        if (!SpeechRecognition) {
-          supportMessage.textContent =
-            "Speech recognition is unavailable. Try using Chrome on desktop.";
-          supportMessage.classList.remove("hidden");
-          startButton.disabled = true;
-          stopButton.disabled = true;
-          return null;
-        }
-        recognition = new SpeechRecognition();
-        recognition.lang = "en-US";
-        recognition.interimResults = false;
-        recognition.maxAlternatives = 1;
-        recognition.continuous = false;
-        recognition.addEventListener("result", handleRecognitionResult);
-        recognition.addEventListener("error", handleRecognitionError);
-        recognition.addEventListener("end", () => {
-          isListening = false;
-          startButton.disabled = false;
-          stopButton.disabled = true;
-          listeningLabel.classList.add("hidden");
-        });
-        return recognition;
-      }
-
-      function startListening() {
-        const rec = ensureRecognition();
-        if (!rec || isListening) return;
-        const { text } = getSelectedParagraph();
-        renderParagraph(text);
-        resultContainer.classList.add("hidden");
-        transcriptEl.textContent = "—";
-        rec.start();
-        isListening = true;
-        listeningLabel.classList.remove("hidden");
-        startButton.disabled = true;
-        stopButton.disabled = false;
-      }
-
-      function stopListening() {
-        if (!recognition || !isListening) return;
-        recognition.stop();
       }
 
       function normaliseTranscript(text) {
@@ -393,14 +358,237 @@
         return analysis;
       }
 
-      function handleRecognitionResult(event) {
-        const { text } = getSelectedParagraph();
-        const transcript = Array.from(event.results)
-          .map((result) => result[0].transcript)
-          .join(" ")
-          .trim();
+      function showSupportMessage(message) {
+        supportMessage.textContent = message;
+        supportMessage.classList.remove("hidden");
+      }
 
-        if (!transcript) return;
+      function hideSupportMessage() {
+        supportMessage.classList.add("hidden");
+        supportMessage.textContent = "";
+      }
+
+      function toggleListening(isActive) {
+        if (isActive) {
+          listeningLabel.classList.remove("hidden");
+        } else {
+          listeningLabel.classList.add("hidden");
+        }
+      }
+
+      function toggleProcessing(isActive) {
+        if (isActive) {
+          processingLabel.classList.remove("hidden");
+        } else {
+          processingLabel.classList.add("hidden");
+        }
+      }
+
+      function getPreferredMimeType() {
+        const preferred = [
+          "audio/webm;codecs=opus",
+          "audio/ogg;codecs=opus",
+          "audio/webm",
+        ];
+        for (const type of preferred) {
+          if (type && MediaRecorder.isTypeSupported(type)) {
+            return type;
+          }
+        }
+        return "";
+      }
+
+      async function startListening() {
+        if (isListening || isProcessing) return;
+        hideSupportMessage();
+
+        if (typeof MediaRecorder === "undefined") {
+          showSupportMessage(
+            "MediaRecorder is not supported in this browser. Try a modern Chromium-based browser."
+          );
+          startButton.disabled = true;
+          stopButton.disabled = true;
+          return;
+        }
+
+        try {
+          activeStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        } catch (error) {
+          showSupportMessage(
+            error.name === "NotAllowedError"
+              ? "Microphone permission was denied. Please allow access and try again."
+              : "Unable to access the microphone."
+          );
+          return;
+        }
+
+        recordedChunks = [];
+        const mimeType = getPreferredMimeType();
+        try {
+          mediaRecorder = new MediaRecorder(activeStream, mimeType ? { mimeType } : undefined);
+        } catch (error) {
+          showSupportMessage("Failed to start audio recorder.");
+          activeStream.getTracks().forEach((track) => track.stop());
+          activeStream = null;
+          return;
+        }
+
+        mediaRecorder.addEventListener("dataavailable", (event) => {
+          if (event.data && event.data.size > 0) {
+            recordedChunks.push(event.data);
+          }
+        });
+
+        mediaRecorder.addEventListener("stop", handleRecordingStop);
+
+        const { text } = getSelectedParagraph();
+        renderParagraph(text);
+        resultContainer.classList.add("hidden");
+        transcriptEl.textContent = "—";
+
+        mediaRecorder.start(1000);
+        isListening = true;
+        toggleListening(true);
+        startButton.disabled = true;
+        stopButton.disabled = false;
+      }
+
+      function stopListening() {
+        if (!mediaRecorder || mediaRecorder.state === "inactive") return;
+        mediaRecorder.stop();
+        stopButton.disabled = true;
+        if (activeStream) {
+          activeStream.getTracks().forEach((track) => track.stop());
+          activeStream = null;
+        }
+      }
+
+      async function handleRecordingStop() {
+        isListening = false;
+        toggleListening(false);
+        stopButton.disabled = true;
+        startButton.disabled = true;
+
+        if (!recordedChunks.length) {
+          showSupportMessage("No audio was captured. Please try again.");
+          startButton.disabled = false;
+          return;
+        }
+
+        try {
+          isProcessing = true;
+          toggleProcessing(true);
+          const wavBlob = await convertChunksToWav(recordedChunks);
+          await submitForTranscription(wavBlob);
+        } catch (error) {
+          console.error(error);
+          showSupportMessage(
+            error?.message || "Something went wrong while processing the recording."
+          );
+        } finally {
+          isProcessing = false;
+          toggleProcessing(false);
+          startButton.disabled = false;
+          recordedChunks = [];
+          mediaRecorder = null;
+        }
+      }
+
+      async function convertChunksToWav(chunks) {
+        const blob = new Blob(chunks);
+        const arrayBuffer = await blob.arrayBuffer();
+        if (!audioContext) {
+          audioContext = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0));
+        return audioBufferToWav(audioBuffer);
+      }
+
+      function audioBufferToWav(audioBuffer) {
+        const sampleRate = audioBuffer.sampleRate;
+        const channelData = [];
+        for (let i = 0; i < audioBuffer.numberOfChannels; i += 1) {
+          channelData.push(audioBuffer.getChannelData(i));
+        }
+
+        const length = audioBuffer.length;
+        const combined = new Float32Array(length);
+        if (channelData.length === 1) {
+          combined.set(channelData[0]);
+        } else {
+          for (let i = 0; i < length; i += 1) {
+            let total = 0;
+            for (let c = 0; c < channelData.length; c += 1) {
+              total += channelData[c][i];
+            }
+            combined[i] = total / channelData.length;
+          }
+        }
+
+        const buffer = new ArrayBuffer(44 + length * 2);
+        const view = new DataView(buffer);
+
+        function writeString(offset, string) {
+          for (let i = 0; i < string.length; i += 1) {
+            view.setUint8(offset + i, string.charCodeAt(i));
+          }
+        }
+
+        writeString(0, "RIFF");
+        view.setUint32(4, 36 + length * 2, true);
+        writeString(8, "WAVE");
+        writeString(12, "fmt ");
+        view.setUint32(16, 16, true); // PCM chunk size
+        view.setUint16(20, 1, true); // format (PCM)
+        view.setUint16(22, 1, true); // mono
+        view.setUint32(24, sampleRate, true);
+        view.setUint32(28, sampleRate * 2, true); // byte rate
+        view.setUint16(32, 2, true); // block align
+        view.setUint16(34, 16, true); // bits per sample
+        writeString(36, "data");
+        view.setUint32(40, length * 2, true);
+
+        let offset = 44;
+        for (let i = 0; i < length; i += 1) {
+          let sample = combined[i];
+          sample = Math.max(-1, Math.min(1, sample));
+          view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+          offset += 2;
+        }
+
+        return new Blob([buffer], { type: "audio/wav" });
+      }
+
+      async function submitForTranscription(wavBlob) {
+        const formData = new FormData();
+        formData.append("audio", wavBlob, "practice.wav");
+        formData.append("language", "en");
+
+        const response = await fetch(API_ENDPOINT, {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(errorText || "Transcription request failed");
+        }
+
+        const payload = await response.json();
+        handleTranscriptionResult(payload);
+      }
+
+      function handleTranscriptionResult(payload) {
+        const transcript = (payload?.text || "").trim();
+        const paragraph =
+          PARAGRAPHS.find((entry) => entry.id === activeParagraphId) || getSelectedParagraph();
+        const { text } = paragraph;
+
+        if (!transcript) {
+          showSupportMessage("No speech was recognised. Please try again.");
+          renderParagraph(text);
+          return;
+        }
 
         const targetTokens = tokenise(text);
         const spokenTokens = normaliseTranscript(transcript);
@@ -410,17 +598,10 @@
         resultContainer.classList.remove("hidden");
       }
 
-      function handleRecognitionError(event) {
-        supportMessage.textContent =
-          event.error === "not-allowed"
-            ? "Microphone permission was denied. Please allow access and try again."
-            : `Speech recognition error: ${event.error}`;
-        supportMessage.classList.remove("hidden");
-      }
-
       paragraphSelect.addEventListener("change", () => {
-        const { text } = getSelectedParagraph();
-        renderParagraph(text);
+        const selected = getSelectedParagraph();
+        activeParagraphId = selected.id;
+        renderParagraph(selected.text);
         resultContainer.classList.add("hidden");
         transcriptEl.textContent = "—";
       });

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 faster-whisper>=0.10.0,<1.0.0
 phonemizer>=3.2,<4.0
 soundfile>=0.12,<0.13
+fastapi>=0.109,<1.0
+uvicorn[standard]>=0.22,<0.29
+python-multipart>=0.0.6,<0.0.8

--- a/speechtoipa/local_server.py
+++ b/speechtoipa/local_server.py
@@ -1,0 +1,167 @@
+"""Local FastAPI server for offline speech-to-IPA transcription."""
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Optional
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+import uvicorn
+
+from .pipeline import load_model, transcribe_audio_to_ipa
+
+LOGGER = logging.getLogger(__name__)
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+app = FastAPI(
+    title="Speech to IPA Local Server",
+    description=(
+        "Accepts uploaded audio snippets, transcribes them with faster-whisper, and "
+        "returns IPA-rich results without contacting external services."
+    ),
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+async def _log_startup() -> None:
+    LOGGER.info("Speech to IPA local server initialised")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def serve_index() -> HTMLResponse:
+    """Serve the demo interface bundled with the repository."""
+
+    index_path = ROOT_DIR / "index.html"
+    if not index_path.exists():
+        raise HTTPException(status_code=404, detail="index.html not found")
+
+    return HTMLResponse(index_path.read_text(encoding="utf-8"))
+
+
+static_dir = ROOT_DIR / "static"
+if static_dir.exists():
+    app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+
+@app.post("/api/transcribe")
+async def transcribe_endpoint(
+    audio: UploadFile = File(...),
+    model_size: str = Form("small"),
+    language: Optional[str] = Form(None),
+    ipa_language: Optional[str] = Form(None),
+    device: str = Form("cpu"),
+    compute_type: Optional[str] = Form(None),
+) -> dict:
+    """Persist the uploaded audio temporarily and return the transcription result."""
+
+    try:
+        audio_bytes = await audio.read()
+    except Exception as exc:  # pragma: no cover - FastAPI handles response
+        raise HTTPException(status_code=400, detail="Unable to read uploaded audio") from exc
+
+    if not audio_bytes:
+        raise HTTPException(status_code=400, detail="Uploaded audio was empty")
+
+    suffix = Path(audio.filename or "recording.wav").suffix or ".wav"
+
+    with NamedTemporaryFile(delete=False, suffix=suffix) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+        tmp_file.write(audio_bytes)
+
+    try:
+        load_model(model_size, device=device, compute_type=compute_type)
+        result = transcribe_audio_to_ipa(
+            tmp_path,
+            model_size=model_size,
+            language=language or None,
+            ipa_language=ipa_language or None,
+            device=device,
+            compute_type=compute_type,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            LOGGER.warning("Failed to delete temporary audio file %s", tmp_path)
+
+    payload = result.to_dict()
+    payload.pop("audio_path", None)
+    return payload
+
+
+def run_server(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    model_size: str = "small",
+    device: str = "cpu",
+    compute_type: Optional[str] = None,
+) -> None:
+    """Warm the requested model and start the FastAPI application."""
+
+    LOGGER.info(
+        "Starting local server (model_size=%s, device=%s, compute_type=%s)",
+        model_size,
+        device,
+        compute_type or "auto",
+    )
+
+    load_model(model_size, device=device, compute_type=compute_type)
+
+    uvicorn.run(
+        "speechtoipa.local_server:app",
+        host=host,
+        port=port,
+        log_level="info",
+        reload=False,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Speech to IPA offline server")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8000, help="Port to serve on (default: 8000)")
+    parser.add_argument(
+        "--model-size",
+        default="small",
+        help="faster-whisper model size to load (e.g. tiny, base, small, medium)",
+    )
+    parser.add_argument(
+        "--device",
+        default="cpu",
+        help="Compute device for faster-whisper (cpu, cuda, auto)",
+    )
+    parser.add_argument(
+        "--compute-type",
+        default=None,
+        help="Optional compute type override for faster-whisper",
+    )
+    args = parser.parse_args()
+
+    run_server(
+        host=args.host,
+        port=args.port,
+        model_size=args.model_size,
+        device=args.device,
+        compute_type=args.compute_type,
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/speechtoipa/pipeline.py
+++ b/speechtoipa/pipeline.py
@@ -6,12 +6,15 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import List, Optional
 
+from functools import lru_cache
+
 from faster_whisper import WhisperModel
 from phonemizer import phonemize
 
 __all__ = [
     "SegmentResult",
     "TranscriptionResult",
+    "load_model",
     "transcribe_audio_to_ipa",
 ]
 
@@ -150,6 +153,28 @@ def _phonemize_text(text: str, ipa_language: str) -> str:
         ) from exc
 
 
+@lru_cache(maxsize=8)
+def _load_model(model_size: str, device: str, compute_type: Optional[str]) -> WhisperModel:
+    """Load and cache ``WhisperModel`` instances for reuse."""
+
+    resolved_compute_type = compute_type
+    if resolved_compute_type is None:
+        resolved_compute_type = "int8" if device == "cpu" else "auto"
+
+    return WhisperModel(model_size, device=device, compute_type=resolved_compute_type)
+
+
+def load_model(
+    model_size: str = "small",
+    *,
+    device: str = "cpu",
+    compute_type: Optional[str] = None,
+) -> WhisperModel:
+    """Public helper to warm and retrieve cached Whisper models."""
+
+    return _load_model(model_size, device, compute_type)
+
+
 def transcribe_audio_to_ipa(
     audio_path: Path | str,
     *,
@@ -166,10 +191,7 @@ def transcribe_audio_to_ipa(
     if not resolved_audio_path.exists():
         raise FileNotFoundError(f"Audio file not found: {resolved_audio_path}")
 
-    if compute_type is None:
-        compute_type = "int8" if device == "cpu" else "auto"
-
-    model = WhisperModel(model_size, device=device, compute_type=compute_type)
+    model = _load_model(model_size, device, compute_type)
     segments_iter, info = model.transcribe(
         str(resolved_audio_path),
         language=language,


### PR DESCRIPTION
## Summary
- add a FastAPI-powered local server that feeds uploads into the existing transcription pipeline
- switch the frontend to record with MediaRecorder, convert to WAV, and call the offline endpoint for results
- document the local-only workflow, dependencies, and new server invocation steps

## Testing
- python -m compileall speechtoipa

------
https://chatgpt.com/codex/tasks/task_e_68e8c36e47fc8333a917753913cd857b