### PR TITLE
Enable streaming pronunciation feedback with incremental analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,26 @@
         color: var(--error);
       }
 
+      .paragraph span.pending {
+        background: rgba(148, 163, 184, 0.18);
+        color: var(--muted);
+      }
+
+      .paragraph span.provisional.correct,
+      .paragraph span.provisional.incorrect {
+        opacity: 0.7;
+      }
+
+      .paragraph span.slow {
+        box-shadow: inset 0 -0.25rem 0 rgba(250, 204, 21, 0.35);
+        color: #facc15;
+      }
+
+      .paragraph span.repeated {
+        box-shadow: inset 0 -0.25rem 0 rgba(192, 132, 252, 0.45);
+        color: #c084fc;
+      }
+
       .status {
         margin-top: 1.5rem;
         display: grid;
@@ -231,6 +251,11 @@
       const transcriptEl = document.getElementById("transcript");
       const supportMessage = document.getElementById("supportMessage");
 
+      const SpeechRecognition =
+        window.SpeechRecognition || window.webkitSpeechRecognition || null;
+      const supportsSpeechRecognition = typeof SpeechRecognition === "function";
+      const SLOW_WORD_THRESHOLD_MS = 1500;
+
       const PARAGRAPHS = [
         {
           id: "orchard",
@@ -259,6 +284,9 @@
       let recordedChunks = [];
       let activeStream = null;
       let audioContext = null;
+      let recognition = null;
+      let recognitionState = null;
+      let shouldRestartRecognition = false;
       let activeParagraphId = null;
 
       const API_ENDPOINT = "/api/transcribe";
@@ -275,15 +303,29 @@
         renderParagraph(PARAGRAPHS[0].text);
       }
 
+      function createEmptyStatus() {
+        return {
+          correctness: "pending",
+          provisional: true,
+          slow: false,
+          repeated: false,
+        };
+      }
+
       function renderParagraph(text, analysis = []) {
         paragraphDisplay.innerHTML = "";
         const targetWords = tokenise(text);
+        const hasAnalysis = Array.isArray(analysis) && analysis.length > 0;
         targetWords.forEach((word, idx) => {
           const span = document.createElement("span");
           span.textContent = word.original + " ";
-          const status = analysis[idx];
-          if (status === "correct") span.classList.add("correct");
-          if (status === "incorrect") span.classList.add("incorrect");
+          if (hasAnalysis) {
+            const status = analysis[idx] || createEmptyStatus();
+            span.classList.add(status.correctness);
+            if (status.provisional) span.classList.add("provisional");
+            if (status.slow) span.classList.add("slow");
+            if (status.repeated) span.classList.add("repeated");
+          }
           paragraphDisplay.append(span);
         });
       }
@@ -334,26 +376,38 @@
           .filter(Boolean);
       }
 
-      function evaluatePronunciation(targetWords, spokenWords) {
+      function evaluatePronunciation(targetWords, spokenWords, options = {}) {
+        const { confirmedCount = 0, metadata = [] } = options;
         const analysis = [];
         let spokenIndex = 0;
         for (let i = 0; i < targetWords.length; i += 1) {
+          const status = createEmptyStatus();
           const target = targetWords[i].cleaned;
           const spoken = spokenWords[spokenIndex];
           if (!spoken) {
-            analysis.push("incorrect");
+            analysis.push(status);
             continue;
           }
+
+          const isConfirmed = spokenIndex < confirmedCount;
+          status.provisional = !isConfirmed;
+
           if (target === spoken) {
-            analysis.push("correct");
-            spokenIndex += 1;
+            status.correctness = "correct";
           } else if (spokenWords[spokenIndex + 1] === target) {
-            analysis.push("incorrect");
-            spokenIndex += 1;
+            status.correctness = "incorrect";
           } else {
-            analysis.push("incorrect");
-            spokenIndex += 1;
+            status.correctness = "incorrect";
           }
+
+          if (isConfirmed) {
+            const meta = metadata[spokenIndex];
+            status.slow = Boolean(meta?.slow);
+            status.repeated = Boolean(meta?.repeated);
+          }
+
+          spokenIndex += 1;
+          analysis.push(status);
         }
         return analysis;
       }
@@ -398,10 +452,173 @@
         return "";
       }
 
-      async function startListening() {
-        if (isListening || isProcessing) return;
-        hideSupportMessage();
+      function prepareParagraphSession(paragraph, { showTranscript } = { showTranscript: false }) {
+        const targetTokens = tokenise(paragraph.text);
+        recognitionState = {
+          targetText: paragraph.text,
+          targetTokens,
+          lockedAnalysis: targetTokens.map(() => null),
+          confirmedMeta: [],
+        };
+        renderParagraph(paragraph.text);
+        transcriptEl.textContent = showTranscript ? "…" : "—";
+        if (showTranscript) {
+          resultContainer.classList.remove("hidden");
+        } else {
+          resultContainer.classList.add("hidden");
+        }
+      }
 
+      function mergeAnalysisWithLocks(analysis) {
+        if (!recognitionState) return analysis;
+        const { lockedAnalysis, targetTokens } = recognitionState;
+        return targetTokens.map((_, idx) => {
+          const current = analysis[idx] || createEmptyStatus();
+          const locked = lockedAnalysis[idx];
+          if (!locked && !current.provisional && current.correctness !== "pending") {
+            lockedAnalysis[idx] = { ...current, provisional: false };
+            return lockedAnalysis[idx];
+          }
+          if (locked && !locked.provisional) {
+            return locked;
+          }
+          return current;
+        });
+      }
+
+      function handleRecognitionResult(event) {
+        if (!recognitionState) return;
+        const { targetTokens, targetText } = recognitionState;
+        const recognitionResults = Array.from(event.currentTarget?.results || event.results || []);
+        const finalTranscript = recognitionResults
+          .filter((result) => result.isFinal)
+          .map((result) => result[0].transcript)
+          .join(" ")
+          .trim();
+        const interimTranscript = recognitionResults
+          .filter((result) => !result.isFinal)
+          .map((result) => result[0].transcript)
+          .join(" ")
+          .trim();
+
+        const finalTokens = normaliseTranscript(finalTranscript);
+        const interimTokens = normaliseTranscript(interimTranscript);
+
+        let confirmedMeta = recognitionState.confirmedMeta;
+
+        if (confirmedMeta.length > finalTokens.length) {
+          confirmedMeta = confirmedMeta.slice(0, finalTokens.length);
+          recognitionState.confirmedMeta = confirmedMeta;
+        }
+
+        if (finalTokens.length > confirmedMeta.length) {
+          const now = typeof performance !== "undefined" && performance.now
+            ? performance.now()
+            : Date.now();
+          for (let i = confirmedMeta.length; i < finalTokens.length; i += 1) {
+            const word = finalTokens[i];
+            const previous = confirmedMeta[i - 1] || null;
+            const delta = previous ? Math.max(0, now - previous.timestamp) : 0;
+            const entry = {
+              word,
+              timestamp: now,
+              slow: previous ? delta > SLOW_WORD_THRESHOLD_MS : false,
+              repeated: previous ? previous.word === word : false,
+            };
+            confirmedMeta.push(entry);
+          }
+          recognitionState.confirmedMeta = confirmedMeta;
+        }
+
+        const combinedTokens = finalTokens.concat(interimTokens);
+        const analysis = evaluatePronunciation(targetTokens, combinedTokens, {
+          confirmedCount: finalTokens.length,
+          metadata: confirmedMeta,
+        });
+        const mergedAnalysis = mergeAnalysisWithLocks(analysis);
+        renderParagraph(targetText, mergedAnalysis);
+
+        const displayTranscript = [finalTranscript, interimTranscript]
+          .filter(Boolean)
+          .join(" ")
+          .trim();
+        transcriptEl.textContent = displayTranscript || "…";
+        resultContainer.classList.remove("hidden");
+      }
+
+      function startSpeechRecognition() {
+        try {
+          recognition = new SpeechRecognition();
+        } catch (error) {
+          console.error(error);
+          showSupportMessage("Speech recognition is unavailable in this browser.");
+          return false;
+        }
+
+        recognition.lang = "en-US";
+        recognition.interimResults = true;
+        recognition.continuous = true;
+        shouldRestartRecognition = true;
+
+        recognition.onresult = handleRecognitionResult;
+        recognition.onstart = () => {
+          isListening = true;
+          toggleListening(true);
+          startButton.disabled = true;
+          stopButton.disabled = false;
+        };
+        recognition.onend = () => {
+          toggleListening(false);
+          isListening = false;
+          if (shouldRestartRecognition) {
+            try {
+              recognition.start();
+            } catch (error) {
+              console.error(error);
+              shouldRestartRecognition = false;
+              startButton.disabled = false;
+              stopButton.disabled = true;
+            }
+          } else {
+            startButton.disabled = false;
+            stopButton.disabled = true;
+            recognition = null;
+          }
+        };
+        recognition.onerror = (event) => {
+          console.error(event);
+          isListening = false;
+          toggleListening(false);
+          showSupportMessage(
+            event.error === "not-allowed"
+              ? "Microphone permission was denied. Please allow access and try again."
+              : "Speech recognition encountered an issue."
+          );
+          shouldRestartRecognition = false;
+          startButton.disabled = false;
+          stopButton.disabled = true;
+          try {
+            recognition.stop();
+          } catch (error) {
+            console.error(error);
+          }
+        };
+
+        try {
+          recognition.start();
+        } catch (error) {
+          console.error(error);
+          shouldRestartRecognition = false;
+          showSupportMessage("Speech recognition could not be started.");
+          startButton.disabled = false;
+          stopButton.disabled = true;
+          return false;
+        }
+
+        return true;
+      }
+
+      async function startMediaRecorderSession(paragraph) {
         if (typeof MediaRecorder === "undefined") {
           showSupportMessage(
             "MediaRecorder is not supported in this browser. Try a modern Chromium-based browser."
@@ -441,11 +658,6 @@
 
         mediaRecorder.addEventListener("stop", handleRecordingStop);
 
-        const { text } = getSelectedParagraph();
-        renderParagraph(text);
-        resultContainer.classList.add("hidden");
-        transcriptEl.textContent = "—";
-
         mediaRecorder.start(1000);
         isListening = true;
         toggleListening(true);
@@ -453,7 +665,39 @@
         stopButton.disabled = false;
       }
 
+      async function startListening() {
+        if (isListening || isProcessing) return;
+        hideSupportMessage();
+
+        const selectedParagraph = getSelectedParagraph();
+        activeParagraphId = selectedParagraph.id;
+
+        if (supportsSpeechRecognition) {
+          prepareParagraphSession(selectedParagraph, { showTranscript: true });
+          const started = startSpeechRecognition();
+          if (!started) {
+            prepareParagraphSession(selectedParagraph, { showTranscript: false });
+            await startMediaRecorderSession(selectedParagraph);
+          }
+        } else {
+          prepareParagraphSession(selectedParagraph, { showTranscript: false });
+          await startMediaRecorderSession(selectedParagraph);
+        }
+      }
+
       function stopListening() {
+        if (recognition) {
+          shouldRestartRecognition = false;
+          isListening = false;
+          try {
+            recognition.stop();
+          } catch (error) {
+            console.error(error);
+          }
+          stopButton.disabled = true;
+          return;
+        }
+
         if (!mediaRecorder || mediaRecorder.state === "inactive") return;
         mediaRecorder.stop();
         stopButton.disabled = true;
@@ -590,10 +834,14 @@
           return;
         }
 
-        const targetTokens = tokenise(text);
+        prepareParagraphSession(paragraph, { showTranscript: true });
+        const targetTokens = recognitionState.targetTokens;
         const spokenTokens = normaliseTranscript(transcript);
-        const analysis = evaluatePronunciation(targetTokens, spokenTokens);
-        renderParagraph(text, analysis);
+        const analysis = evaluatePronunciation(targetTokens, spokenTokens, {
+          confirmedCount: spokenTokens.length,
+        });
+        const mergedAnalysis = mergeAnalysisWithLocks(analysis);
+        renderParagraph(text, mergedAnalysis);
         transcriptEl.textContent = transcript;
         resultContainer.classList.remove("hidden");
       }
@@ -604,6 +852,7 @@
         renderParagraph(selected.text);
         resultContainer.classList.add("hidden");
         transcriptEl.textContent = "—";
+        recognitionState = null;
       });
 
       playButton.addEventListener("click", speakParagraph);


### PR DESCRIPTION
## Summary
- enable Web Speech streaming recognition with interim transcripts and session resilience
- diff interim/final transcripts against the target text and retain confirmed highlights to avoid flicker
- flag slow or repeated words in real time and adjust styles to reflect timing heuristics

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e8cfbc08e08333bb932972f00b9a68