### PR TITLE
Adjust landing title size and remove intro paragraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 
       h1 {
         margin-top: 0;
-        font-size: clamp(2.5rem, 5vw, 3.25rem);
+        font-size: clamp(2rem, calc(5vw - 0.5rem), 2.75rem);
         line-height: 1.1;
         color: var(--accent);
       }
@@ -256,12 +256,6 @@
   <body>
     <main>
       <h1>Reading Pronunciation Practice</h1>
-      <p>
-        Choose a paragraph, listen to the model reader, then record yourself
-        reading aloud. The site compares the recognised transcript to the target
-        text and colours each word green or red to highlight potential
-        mispronunciations.
-      </p>
       <div class="controls">
         <div class="control-row">
           <label for="paragraph">Paragraph</label>


### PR DESCRIPTION
## Summary
- reduce the main page heading size by approximately 6 points
- remove the introductory instructional paragraph from the landing page

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e8f92f2c3083338089c774c0af1d56