### PR TITLE
Move speech synthesis initialization before voice handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,6 +571,7 @@
       const SpeechRecognition =
         window.SpeechRecognition || window.webkitSpeechRecognition || null;
       const supportsSpeechRecognition = typeof SpeechRecognition === "function";
+      const synth = window.speechSynthesis;
       const SLOW_WORD_THRESHOLD_MS = 1500;
       const CLOSE_SIMILARITY_THRESHOLD = 0.5;
       const MATCH_LOOKAHEAD_LIMIT = 6;
@@ -954,7 +955,6 @@
         },
       ];
 
-      const synth = window.speechSynthesis;
       let isListening = false;
       let isProcessing = false;
       let mediaRecorder = null;


### PR DESCRIPTION
## Summary
- move the speech synthesis initialization before registering voice dropdown handlers so it is available when the options are populated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea1d332854833380461909afc92c48