### PR TITLE
Add Italian, Arabic, and Catalan language options

### DIFF
--- a/index.html
+++ b/index.html
@@ -502,6 +502,9 @@
                 <option value="fr-FR" data-transcribe="fr">French (France)</option>
                 <option value="de-DE" data-transcribe="de">German (Germany)</option>
                 <option value="ja-JP" data-transcribe="ja">Japanese</option>
+                <option value="it-IT" data-transcribe="it">Italian (Italy)</option>
+                <option value="ar-SA" data-transcribe="ar">Arabic</option>
+                <option value="ca-ES" data-transcribe="ca">Catalan</option>
               </select>
             </div>
             <div class="field">
@@ -513,6 +516,9 @@
                 <option value="fr">French</option>
                 <option value="de">German</option>
                 <option value="ja">Japanese</option>
+                <option value="it">Italian</option>
+                <option value="ar">Arabic</option>
+                <option value="ca">Catalan</option>
               </select>
             </div>
           </div>

--- a/speechtoipa/pipeline.py
+++ b/speechtoipa/pipeline.py
@@ -60,6 +60,7 @@ _ESPEAK_LANG_MAP = {
     "zh": "zh",
     "zh-cn": "zh",
     "zh-tw": "zh",
+    "ca": "ca",
 }
 
 _PUNCTUATION = ";:,.!?¡¿—…\"«»“”()[]{}"


### PR DESCRIPTION
## Summary
- add Italian, Arabic, and Catalan to the recognition language dropdown
- expose matching IPA override options for the new languages
- map Catalan to the espeak-ng language code for explicit support

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ea1edc537c8333868a10bd4f413c87