### PR TITLE
Set large-v2 as the default Whisper model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ highlight potential pronunciation slips.
    pip install -r requirements.txt
    ```
    The first transcription will automatically download the requested
-   faster-whisper model (default: `small`) into your local cache. To control the
+   faster-whisper model (default: `large-v2`) into your local cache. To control the
    location, set `FWHISPER_ASSET_DIR` before running the server.
 2. Launch the offline inference endpoint:
    ```bash
-   python -m speechtoipa.local_server --host 127.0.0.1 --port 8000 --model-size small
+   python -m speechtoipa.local_server --host 127.0.0.1 --port 8000 --model-size large-v2
    ```
    Use `--device cuda` and an appropriate `--compute-type` if you have a GPU.
    The server also serves `index.html`, so you can point your browser straight

--- a/index.html
+++ b/index.html
@@ -455,13 +455,13 @@
         >
           <div class="advanced-grid">
             <div class="field">
-              <label for="advancedModelSize">Model size</label>
+              <label for="advancedModelSize">Model size (Large v2 default)</label>
               <select id="advancedModelSize">
                 <option value="tiny">Tiny (fastest)</option>
                 <option value="base">Base</option>
-                <option value="small" selected>Small (default)</option>
+                <option value="small">Small</option>
                 <option value="medium">Medium</option>
-                <option value="large-v2">Large v2</option>
+                <option value="large-v2" selected>Large v2 (default)</option>
               </select>
             </div>
             <div class="field">
@@ -592,7 +592,7 @@
         defaultRecognitionLocale.split("-")[0] || "en";
 
       const defaultAdvancedConfig = {
-        modelSize: "small",
+        modelSize: "large-v2",
         device: "cpu",
         computeType: "",
         recognitionLocale: defaultRecognitionLocale,

--- a/speechtoipa/cli.py
+++ b/speechtoipa/cli.py
@@ -17,7 +17,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("audio", type=Path, help="Path to the input audio file (any ffmpeg-compatible format).")
     parser.add_argument(
         "--model",
-        default="small",
+        default="large-v2",
         help="Whisper model size to download/use (tiny, base, small, medium, large-v2, etc.).",
     )
     parser.add_argument(

--- a/speechtoipa/local_server.py
+++ b/speechtoipa/local_server.py
@@ -59,7 +59,7 @@ if static_dir.exists():
 @app.post("/api/transcribe")
 async def transcribe_endpoint(
     audio: UploadFile = File(...),
-    model_size: str = Form("small"),
+    model_size: str = Form("large-v2"),
     language: Optional[str] = Form(None),
     ipa_language: Optional[str] = Form(None),
     device: str = Form("cpu"),
@@ -131,7 +131,7 @@ def run_server(
     *,
     host: str = "127.0.0.1",
     port: int = 8000,
-    model_size: str = "small",
+    model_size: str = "large-v2",
     device: str = "cpu",
     compute_type: Optional[str] = None,
 ) -> None:
@@ -161,7 +161,7 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=8000, help="Port to serve on (default: 8000)")
     parser.add_argument(
         "--model-size",
-        default="small",
+        default="large-v2",
         help="faster-whisper model size to load (e.g. tiny, base, small, medium)",
     )
     parser.add_argument(

--- a/speechtoipa/pipeline.py
+++ b/speechtoipa/pipeline.py
@@ -166,7 +166,7 @@ def _load_model(model_size: str, device: str, compute_type: Optional[str]) -> Wh
 
 
 def load_model(
-    model_size: str = "small",
+    model_size: str = "large-v2",
     *,
     device: str = "cpu",
     compute_type: Optional[str] = None,
@@ -179,7 +179,7 @@ def load_model(
 def transcribe_audio_to_ipa(
     audio_path: Path | str,
     *,
-    model_size: str = "small",
+    model_size: str = "large-v2",
     language: Optional[str] = None,
     ipa_language: Optional[str] = None,
     device: str = "cpu",


### PR DESCRIPTION
## Summary
- default the Python pipeline helpers, CLI, and local server to the large-v2 faster-whisper model
- update the web UI to highlight large-v2 as the default advanced model option
- refresh documentation to reflect the new default model and sample command

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ea2204e8b88333a5be290892ef9a38