### PR TITLE
Show Browser default while loading TTS voices

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,7 +764,7 @@
         if (voices.length === 0) {
           const loadingOption = document.createElement("option");
           loadingOption.value = "";
-          loadingOption.textContent = "Loading available voices…";
+          loadingOption.textContent = "Browser default";
           ttsVoiceSelect.append(loadingOption);
           ttsVoiceSelect.disabled = true;
           if (voiceRetryTimeoutId === null) {


### PR DESCRIPTION
## Summary
- replace the placeholder "Loading available voices…" option in the advanced TTS voice selector with "Browser default" so it matches the desired label while voices load

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eac3dfcc648333a9e1daf0a2a78faa