### PR TITLE
Adjust language controls layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,20 @@
         color: var(--accent);
       }
 
+      .app-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1.25rem;
+        flex-wrap: wrap;
+        margin-bottom: 1.75rem;
+      }
+
+      .app-header h1 {
+        margin: 0;
+        flex: 1 1 auto;
+      }
+
       p {
         line-height: 1.6;
         margin: 0 0 1rem;
@@ -67,26 +81,24 @@
         margin: 1.5rem 0 2rem;
       }
 
-      .language-toggle-row {
-        justify-content: space-between;
-      }
-
       .language-toggle {
         display: inline-flex;
+        align-items: center;
         background: rgba(148, 163, 184, 0.12);
         border: 1px solid rgba(148, 163, 184, 0.25);
         border-radius: 999px;
-        padding: 0.25rem;
-        gap: 0.25rem;
+        padding: 0.2rem;
+        gap: 0.2rem;
       }
 
       .language-button {
         border: none;
         background: transparent;
         color: inherit;
-        padding: 0.45rem 1rem;
+        padding: 0.35rem 0.85rem;
         border-radius: 999px;
         font-weight: 600;
+        font-size: 0.9rem;
         cursor: pointer;
         transition: background 120ms ease, color 120ms ease;
       }
@@ -117,13 +129,46 @@
       .practice-selects {
         display: flex;
         flex-wrap: wrap;
-        gap: 0.75rem;
+        gap: 0.65rem;
         align-items: center;
+      }
+
+      .practice-language {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        flex: 0 1 auto;
+        white-space: nowrap;
+      }
+
+      .practice-label {
+        margin: 0;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        padding: 0.55rem 1.1rem;
+        background: rgba(148, 163, 184, 0.12);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 999px;
+        cursor: pointer;
+        transition: background 120ms ease, border 120ms ease;
+      }
+
+      .practice-label:hover,
+      .practice-label:focus-visible {
+        background: rgba(148, 163, 184, 0.18);
+        border-color: rgba(148, 163, 184, 0.45);
+        outline: none;
       }
 
       .practice-selects select {
         flex: 1;
         min-width: 200px;
+      }
+
+      .practice-language select {
+        flex: 0 1 180px;
+        min-width: 170px;
       }
 
       select,
@@ -559,20 +604,6 @@
           align-items: stretch;
         }
 
-        .language-toggle-row {
-          align-items: flex-start;
-          gap: 0.5rem;
-        }
-
-        .language-toggle {
-          width: 100%;
-          justify-content: space-between;
-        }
-
-        .language-button {
-          flex: 1;
-        }
-
         select,
         button,
         textarea {
@@ -592,48 +623,75 @@
           gap: 0.3rem;
         }
 
+        .app-header {
+          flex-direction: column;
+          align-items: stretch;
+          gap: 1rem;
+        }
+
+        .language-toggle {
+          align-self: flex-start;
+        }
+
         .practice-selects {
           flex-direction: column;
           align-items: stretch;
+        }
+
+        .practice-language {
+          flex-direction: column;
+          align-items: stretch;
+          gap: 0.5rem;
+        }
+
+        .practice-label {
+          justify-content: center;
+        }
+
+        .practice-language select {
+          width: 100%;
         }
       }
     </style>
   </head>
   <body>
     <main>
-      <h1 id="appTitle">Pronunciation Practice</h1>
-      <div class="controls">
-        <div
-          class="control-row language-toggle-row"
-          role="group"
-          aria-label="Interface language"
-        >
-          <div class="language-toggle">
-            <button
-              type="button"
-              class="language-button active"
-              data-language="en"
-            >
-              EN
-            </button>
-            <button
-              type="button"
-              class="language-button"
-              data-language="ca"
-            >
-              CA
-            </button>
-          </div>
+      <div class="app-header">
+        <h1 id="appTitle">Pronunciation Practice</h1>
+        <div class="language-toggle" role="group" aria-label="Interface language">
+          <button
+            type="button"
+            class="language-button active"
+            data-language="en"
+          >
+            EN
+          </button>
+          <button
+            type="button"
+            class="language-button"
+            data-language="ca"
+          >
+            CA
+          </button>
         </div>
+      </div>
+      <div class="controls">
         <div class="control-row stack" id="customTextRow">
-          <label id="practiceLabel" for="recognitionLanguage">Practice</label>
           <div class="practice-selects">
-            <select id="recognitionLanguage">
-              <option value="en-US" data-transcribe="en">
-                English
-              </option>
-              <option value="ca-ES" data-transcribe="ca">Catalan</option>
-              <option value="fr-FR" data-transcribe="fr">French</option>
+            <div class="practice-language">
+              <label
+                id="practiceLabel"
+                class="practice-label"
+                for="recognitionLanguage"
+              >
+                Practise
+              </label>
+              <select id="recognitionLanguage">
+                <option value="en-US" data-transcribe="en">
+                  English
+                </option>
+                <option value="ca-ES" data-transcribe="ca">Catalan</option>
+                <option value="fr-FR" data-transcribe="fr">French</option>
               <option value="it-IT" data-transcribe="it">Italian</option>
               <option value="ar-SA" data-transcribe="ar">Arabic</option>
             </select>
@@ -779,7 +837,7 @@
     <script>
       const htmlElement = document.documentElement;
       const appTitle = document.getElementById("appTitle");
-      const languageToggleRow = document.querySelector(".language-toggle-row");
+      const languageToggle = document.querySelector(".language-toggle");
       const languageButtons = Array.from(
         document.querySelectorAll(".language-button"),
       );
@@ -868,7 +926,7 @@
           interfaceLanguageAriaLabel: "Interface language",
           interfaceLanguageEnglish: "EN",
           interfaceLanguageCatalan: "CA",
-          practiceLabel: "Practice",
+          practiceLabel: "Practise",
           paragraphSelectAria: "Choose a practice passage",
           customTextAria: "Practice text editor",
           customTextPlaceholder: "Type or paste the text you want to practise.",
@@ -969,7 +1027,7 @@
           interfaceLanguageAriaLabel: "Idioma de la interfície",
           interfaceLanguageEnglish: "EN",
           interfaceLanguageCatalan: "CA",
-          practiceLabel: "Pràctica",
+          practiceLabel: "Practica",
           paragraphSelectAria: "Tria un fragment de pràctica",
           customTextAria: "Editor de text de pràctica",
           customTextPlaceholder: "Escriu o enganxa el text amb què vols practicar.",
@@ -1564,8 +1622,8 @@
         if (appTitle) {
           appTitle.textContent = t("appHeading");
         }
-        if (languageToggleRow) {
-          languageToggleRow.setAttribute(
+        if (languageToggle) {
+          languageToggle.setAttribute(
             "aria-label",
             t("interfaceLanguageAriaLabel"),
           );


### PR DESCRIPTION
## Summary
- move the interface language toggle alongside the title and shrink the buttons
- restyle the practise label and language selector so they read as a single phrase
- update the practise label copy for English and Catalan locales

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ecea1fbf5c833397d5447de5d73b79