### PR TITLE
Add success modal for perfect pronunciation

### DIFF
--- a/index.html
+++ b/index.html
@@ -590,6 +590,54 @@
         transform: scale(0.97);
       }
 
+      .success-modal {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.75);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        z-index: 30;
+      }
+
+      .success-modal__content {
+        background: linear-gradient(145deg, rgba(34, 197, 94, 0.15), rgba(56, 189, 248, 0.18));
+        border: 1px solid rgba(56, 189, 248, 0.4);
+        border-radius: 20px;
+        padding: 1.75rem 2rem;
+        text-align: center;
+        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.55);
+        min-width: 240px;
+      }
+
+      .success-modal__emoji {
+        font-size: 2.5rem;
+        margin-bottom: 1rem;
+      }
+
+      .success-modal__button {
+        background: var(--accent);
+        color: #02131f;
+        border: none;
+        font-weight: 700;
+        letter-spacing: 0.01em;
+        padding: 0.65rem 1.5rem;
+        border-radius: 12px;
+        cursor: pointer;
+        transition: background 120ms ease, transform 120ms ease;
+      }
+
+      .success-modal__button:hover,
+      .success-modal__button:focus-visible {
+        background: var(--accent-strong);
+        outline: none;
+      }
+
+      .success-modal__button:active {
+        transform: scale(0.98);
+      }
+
       .hidden {
         display: none !important;
       }
@@ -834,6 +882,22 @@
       </section>
     </main>
 
+    <div
+      id="successModal"
+      class="success-modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+      aria-label="Practice complete"
+    >
+      <div class="success-modal__content">
+        <div class="success-modal__emoji" aria-hidden="true">🏆</div>
+        <button type="button" id="successModalClose" class="success-modal__button">
+          OK
+        </button>
+      </div>
+    </div>
+
     <script>
       const htmlElement = document.documentElement;
       const appTitle = document.getElementById("appTitle");
@@ -893,6 +957,8 @@
       const historyHelperEl = document.getElementById("historyHelper");
       const historyEmptyEl = document.getElementById("historyEmpty");
       const historyListEl = document.getElementById("historyList");
+      const successModal = document.getElementById("successModal");
+      const successModalClose = document.getElementById("successModalClose");
 
       const SpeechRecognition =
         window.SpeechRecognition || window.webkitSpeechRecognition || null;
@@ -2288,6 +2354,7 @@
       let shouldRestartRecognition = false;
       let activeParagraphId = null;
       let allowWordPlayback = false;
+      let hasShownSuccessCelebration = false;
 
       const API_ENDPOINT = "/api/transcribe";
 
@@ -2825,6 +2892,22 @@
         };
       }
 
+      function isPerfectPronunciation(targetWords, analysis) {
+        if (!Array.isArray(targetWords) || !Array.isArray(analysis)) {
+          return false;
+        }
+        if (!targetWords.length) {
+          return false;
+        }
+        const relevantAnalysis = analysis.slice(0, targetWords.length);
+        if (relevantAnalysis.length < targetWords.length) {
+          return false;
+        }
+        return relevantAnalysis.every(
+          (status) => status && status.correctness === "correct",
+        );
+      }
+
       function getWordFeedback(status) {
         if (!status) return "";
         const messages = [];
@@ -2870,10 +2953,38 @@
         supportMessage.textContent = "";
       }
 
+      function hideSuccessCelebration() {
+        if (!successModal) {
+          return;
+        }
+        successModal.classList.add("hidden");
+        successModal.classList.remove("active");
+        successModal.setAttribute("aria-hidden", "true");
+      }
+
+      function resetSuccessCelebration() {
+        hasShownSuccessCelebration = false;
+        hideSuccessCelebration();
+      }
+
+      function showSuccessCelebration() {
+        if (!successModal || hasShownSuccessCelebration) {
+          return;
+        }
+        successModal.classList.remove("hidden");
+        successModal.classList.add("active");
+        successModal.removeAttribute("aria-hidden");
+        hasShownSuccessCelebration = true;
+        if (successModalClose) {
+          successModalClose.focus();
+        }
+      }
+
       function resetResultDisplay() {
         resultContainer.classList.add("hidden");
         transcriptEl.textContent = "—";
         recognitionState = null;
+        resetSuccessCelebration();
         updatePlayButtonState();
       }
 
@@ -2914,6 +3025,7 @@
         if (isCustomParagraphId(paragraph.id)) {
           setCustomText(paragraph.id, paragraph.text);
         }
+        resetSuccessCelebration();
         const targetTokens = tokenise(paragraph.text);
         recognitionState = {
           paragraphId: paragraph.id,
@@ -3091,16 +3203,18 @@
         const hasSpokenAllTargets =
           confirmedTokens.length >= targetTokens.length && targetTokens.length > 0;
         const analysisSlice = hasSpokenAllTargets
-          ? analysis.slice(0, targetTokens.length)
+          ? mergedAnalysis.slice(0, targetTokens.length)
           : [];
-        const completedSuccessfully =
-          hasSpokenAllTargets &&
-          analysisSlice.every(
-            (status) => status && status.correctness === "correct"
-          );
+        const completedSuccessfully = isPerfectPronunciation(
+          targetTokens,
+          analysisSlice,
+        );
 
-        if (completedSuccessfully && recognition) {
-          toggleListening(true);
+        if (completedSuccessfully) {
+          showSuccessCelebration();
+          if (recognition) {
+            toggleListening(true);
+          }
         }
 
         const confirmedTranscript = confirmedTokens.join(" ");
@@ -3510,6 +3624,9 @@
             ? transcript
             : alignedTranscript;
         resultContainer.classList.remove("hidden");
+        if (isPerfectPronunciation(targetTokens, mergedAnalysis)) {
+          showSuccessCelebration();
+        }
         recordPracticeHistory(paragraph, targetTokens, mergedAnalysis);
       }
 
@@ -3704,6 +3821,28 @@
           playParagraphText();
         });
       }
+
+      if (successModalClose) {
+        successModalClose.addEventListener("click", hideSuccessCelebration);
+      }
+
+      if (successModal) {
+        successModal.addEventListener("click", (event) => {
+          if (event.target === successModal) {
+            hideSuccessCelebration();
+          }
+        });
+      }
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter") {
+          return;
+        }
+        if (successModal && !successModal.classList.contains("hidden")) {
+          event.preventDefault();
+          hideSuccessCelebration();
+        }
+      });
 
       startButton.addEventListener("click", startListening);
       stopButton.addEventListener("click", stopListening);


### PR DESCRIPTION
## Summary
- add a celebratory success modal with emoji and OK control for perfect pronunciations
- trigger the celebration when all recognised words are correct across live and uploaded sessions
- style and reset the modal alongside practice flows for accessibility and focus handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eac903ae883339be7f36dd803ec5e)