### PR TITLE
Stop recognition when practice is completed

### DIFF
--- a/index.html
+++ b/index.html
@@ -2968,6 +2968,7 @@
       }
 
       function showSuccessCelebration() {
+        stopListening();
         if (!successModal || hasShownSuccessCelebration) {
           return;
         }
@@ -3212,9 +3213,6 @@
 
         if (completedSuccessfully) {
           showSuccessCelebration();
-          if (recognition) {
-            toggleListening(true);
-          }
         }
 
         const confirmedTranscript = confirmedTokens.join(" ");


### PR DESCRIPTION
## Summary
- stop the active recording when the success celebration triggers
- avoid keeping the listening indicator active after completing practice

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eb29c7b20833395fbda617c1ea06a)