### PR TITLE
Celebrate when success support text appears

### DIFF
--- a/index.html
+++ b/index.html
@@ -2980,6 +2980,13 @@
       function showSupportMessage(message) {
         supportMessage.textContent = message;
         supportMessage.classList.remove("hidden");
+
+        if (
+          typeof message === "string" &&
+          message.trim().toLowerCase().startsWith("success")
+        ) {
+          showSuccessCelebration();
+        }
       }
 
       function hideSupportMessage() {


### PR DESCRIPTION
## Summary
- trigger the success celebration modal when the support message reports success
- keep existing perfect-pronunciation triggers unchanged while aligning support messaging with the celebration hook

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f236528708333ad990434ca40d90b)