### PR TITLE
Normalize support success detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2981,10 +2981,16 @@
         supportMessage.textContent = message;
         supportMessage.classList.remove("hidden");
 
-        if (
-          typeof message === "string" &&
-          message.trim().toLowerCase().startsWith("success")
-        ) {
+        if (typeof message !== "string") {
+          return;
+        }
+
+        const normalizedMessage = message
+          .trim()
+          .replace(/^[^a-z0-9]+/i, "")
+          .toLowerCase();
+
+        if (normalizedMessage.startsWith("success")) {
           showSuccessCelebration();
         }
       }


### PR DESCRIPTION
## Summary
- normalize support messages before evaluating success
- allow leading emojis or punctuation to trigger success celebration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2b238d5c8333aa96463c00f13ce0)