### PR TITLE
Simplify UI styling and harden controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,16 +6,15 @@
     <title>Pronunciation Practice</title>
     <style>
       :root {
-        color-scheme: light dark;
-        --bg: #0f172a;
-        --surface: rgba(15, 23, 42, 0.88);
-        --accent: #38bdf8;
-        --accent-strong: #0ea5e9;
-        --text: #e2e8f0;
-        --muted: #94a3b8;
-        --success: #22c55e;
-        --error: #ef4444;
-        --close: #f97316;
+        --bg: #f7f8fa;
+        --surface: #ffffff;
+        --accent: #2563eb;
+        --accent-strong: #1d4ed8;
+        --text: #0f172a;
+        --muted: #475569;
+        --success: #15803d;
+        --error: #b91c1c;
+        --close: #c2410c;
       }
 
       * {
@@ -36,11 +35,11 @@
       }
 
       main {
-        width: min(880px, 100%);
+        width: min(960px, 100%);
         background: var(--surface);
-        padding: clamp(2rem, 4vw, 3rem);
-        border-radius: 28px;
-        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.65);
+        padding: clamp(1.5rem, 4vw, 2.5rem);
+        border-radius: 12px;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
       }
 
       h1 {
@@ -54,9 +53,9 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 1.25rem;
+        gap: 1rem;
         flex-wrap: wrap;
-        margin-bottom: 1.75rem;
+        margin-bottom: 1.25rem;
       }
 
       .app-header h1 {
@@ -79,40 +78,41 @@
       .controls {
         display: grid;
         gap: 1rem;
-        margin: 1.5rem 0 2rem;
+        margin: 1rem 0 1.5rem;
       }
 
       .language-toggle {
         display: inline-flex;
         align-items: center;
-        background: rgba(148, 163, 184, 0.12);
-        border: 1px solid rgba(148, 163, 184, 0.25);
-        border-radius: 999px;
-        padding: 0.2rem;
-        gap: 0.2rem;
+        background: #e2e8f0;
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        padding: 0.25rem;
+        gap: 0.25rem;
       }
 
       .language-button {
         border: none;
         background: transparent;
         color: inherit;
-        padding: 0.35rem 0.85rem;
-        border-radius: 999px;
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
         font-weight: 600;
-        font-size: 0.9rem;
+        font-size: 0.95rem;
         cursor: pointer;
-        transition: background 120ms ease, color 120ms ease;
+        transition: background 120ms ease, color 120ms ease, border 120ms ease;
       }
 
       .language-button:hover,
       .language-button:focus-visible {
-        background: rgba(148, 163, 184, 0.24);
+        background: #cbd5e1;
+        border: 1px solid #94a3b8;
         outline: none;
       }
 
       .language-button.active {
         background: var(--accent);
-        color: #02131f;
+        color: #ffffff;
       }
 
       .control-row {
@@ -171,18 +171,18 @@
         font-weight: 600;
         display: inline-flex;
         align-items: center;
-        padding: 0.55rem 1.1rem;
-        background: rgba(148, 163, 184, 0.12);
-        border: 1px solid rgba(148, 163, 184, 0.25);
-        border-radius: 999px;
+        padding: 0.55rem 1rem;
+        background: #e2e8f0;
+        border: 1px solid #cbd5e1;
+        border-radius: 10px;
         cursor: pointer;
         transition: background 120ms ease, border 120ms ease;
       }
 
       .practice-label:hover,
       .practice-label:focus-visible {
-        background: rgba(148, 163, 184, 0.18);
-        border-color: rgba(148, 163, 184, 0.45);
+        background: #cbd5e1;
+        border-color: #94a3b8;
         outline: none;
       }
 
@@ -205,36 +205,36 @@
       select,
       input,
       button {
-        background: rgba(148, 163, 184, 0.12);
-        color: inherit;
-        border: 1px solid rgba(148, 163, 184, 0.25);
-        border-radius: 999px;
-        padding: 0.65rem 1.25rem;
+        background: #ffffff;
+        color: var(--text);
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        padding: 0.65rem 1rem;
         transition: background 120ms ease, border 120ms ease, transform 120ms ease;
       }
 
       select {
-        min-width: 220px;
-        background-color: rgba(15, 23, 42, 0.92);
+        min-width: 240px;
+        background-color: #ffffff;
         color: var(--text);
-        border-color: rgba(148, 163, 184, 0.45);
+        border-color: #94a3b8;
         box-shadow: none;
-        border-radius: 12px;
-        padding: 0.6rem 1rem;
+        border-radius: 8px;
+        padding: 0.65rem 0.9rem;
       }
 
       input[type="text"] {
         min-width: 200px;
-        background-color: rgba(15, 23, 42, 0.88);
+        background-color: #ffffff;
         color: var(--text);
-        border-color: rgba(148, 163, 184, 0.45);
-        padding: 0.65rem 1rem;
-        border-radius: 12px;
+        border-color: #94a3b8;
+        padding: 0.65rem 0.9rem;
+        border-radius: 8px;
       }
 
       select option {
-        background-color: #1e293b;
-        color: #f8fafc;
+        background-color: #e2e8f0;
+        color: #0f172a;
       }
 
       select:focus,
@@ -245,8 +245,8 @@
 
       button:hover,
       select:hover {
-        background: rgba(148, 163, 184, 0.2);
-        border-color: rgba(148, 163, 184, 0.45);
+        background: #e2e8f0;
+        border-color: #94a3b8;
       }
 
       button:active {
@@ -255,14 +255,14 @@
 
       button.practice-button {
         background: var(--success);
-        color: #052e16;
+        color: #ffffff;
         border: none;
         font-weight: 600;
         letter-spacing: 0.02em;
       }
 
       button.practice-button:hover {
-        background: #16a34a;
+        background: #166534;
       }
 
       button[disabled] {
@@ -299,15 +299,15 @@
 
       .add-custom-button {
         align-self: flex-start;
-        background: rgba(56, 189, 248, 0.15);
-        border-color: rgba(56, 189, 248, 0.35);
+        background: #e0f2fe;
+        border-color: #bae6fd;
         color: var(--accent);
         font-weight: 600;
       }
 
       .add-custom-button:hover {
-        background: rgba(56, 189, 248, 0.25);
-        border-color: rgba(56, 189, 248, 0.55);
+        background: #bfdbfe;
+        border-color: #93c5fd;
       }
 
       .legend-card {
@@ -315,12 +315,12 @@
         top: calc(100% + 0.75rem);
         right: 0;
         width: max(260px, 50%);
-        background: rgba(15, 23, 42, 0.92);
-        border: 1px solid rgba(148, 163, 184, 0.3);
-        border-radius: 16px;
+        background: #ffffff;
+        border: 1px solid #cbd5e1;
+        border-radius: 12px;
         padding: 1rem;
         color: var(--text);
-        box-shadow: 0 18px 30px rgba(15, 23, 42, 0.55);
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
         opacity: 0;
         pointer-events: none;
         transform: translateY(-6px);
@@ -362,9 +362,9 @@
         font-size: clamp(1.1rem, 2.5vw, 1.3rem);
         line-height: 1.75;
         padding: 1.5rem;
-        border-radius: 20px;
-        background: rgba(15, 23, 42, 0.55);
-        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 12px;
+        background: #ffffff;
+        border: 1px solid #cbd5e1;
         min-height: 140px;
         transition: border 200ms ease;
         white-space: pre-wrap;
@@ -379,14 +379,14 @@
       }
 
       .paragraph[contenteditable="true"] {
-        background: rgba(148, 163, 184, 0.12);
-        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: #e2e8f0;
+        border: 1px solid #94a3b8;
       }
 
       .paragraph[contenteditable="true"]:focus {
-        background: rgba(148, 163, 184, 0.18);
-        border-color: rgba(148, 163, 184, 0.45);
-        box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+        background: #e2e8f0;
+        border-color: #2563eb;
+        box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.18);
       }
 
       .paragraph[data-placeholder]:empty::before {
@@ -467,8 +467,8 @@
       }
 
       .advanced-settings {
-        background: rgba(148, 163, 184, 0.12);
-        border-radius: 20px;
+        background: #e2e8f0;
+        border-radius: 12px;
         padding: 1.25rem;
         display: grid;
         gap: 1rem;
@@ -512,8 +512,8 @@
       .status .transcript {
         font-family: "Fira Code", "Source Code Pro", monospace;
         white-space: pre-wrap;
-        background: rgba(148, 163, 184, 0.12);
-        border-radius: 16px;
+        background: #e2e8f0;
+        border-radius: 12px;
         padding: 1rem;
         color: var(--text);
       }
@@ -551,9 +551,9 @@
       }
 
       .history-card {
-        background: rgba(15, 23, 42, 0.7);
-        border: 1px solid rgba(148, 163, 184, 0.2);
-        border-radius: 20px;
+        background: #ffffff;
+        border: 1px solid #cbd5e1;
+        border-radius: 12px;
         padding: 1.25rem;
         display: grid;
         gap: 0.75rem;
@@ -647,8 +647,8 @@
 
       .history-remove:hover,
       .history-remove:focus-visible {
-        background: rgba(239, 68, 68, 0.2);
-        border-color: rgba(239, 68, 68, 0.55);
+        background: #fecdd3;
+        border-color: #fca5a5;
         outline: none;
       }
 
@@ -659,7 +659,7 @@
       .success-modal {
         position: fixed;
         inset: 0;
-        background: rgba(15, 23, 42, 0.75);
+        background: rgba(15, 23, 42, 0.35);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -668,12 +668,12 @@
       }
 
       .success-modal__content {
-        background: linear-gradient(145deg, rgba(34, 197, 94, 0.15), rgba(56, 189, 248, 0.18));
-        border: 1px solid rgba(56, 189, 248, 0.4);
-        border-radius: 20px;
-        padding: 1.75rem 2rem;
+        background: #ffffff;
+        border: 1px solid #cbd5e1;
+        border-radius: 12px;
+        padding: 1.5rem 1.75rem;
         text-align: center;
-        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.55);
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
         min-width: 240px;
         position: relative;
         overflow: hidden;
@@ -715,7 +715,7 @@
 
       .success-modal__button {
         background: var(--accent);
-        color: #02131f;
+        color: #ffffff;
         border: none;
         font-weight: 700;
         letter-spacing: 0.01em;
@@ -4646,8 +4646,13 @@
         }
       });
 
-      startButton.addEventListener("click", startListening);
-      stopButton.addEventListener("click", stopListening);
+      if (startButton) {
+        startButton.addEventListener("click", startListening);
+      }
+
+      if (stopButton) {
+        stopButton.addEventListener("click", stopListening);
+      }
 
       populateParagraphs();
       applyStaticTranslations();


### PR DESCRIPTION
## Summary
- simplify the interface palette for higher contrast and consistent control sizing
- update practice, history, and modal components to plain surfaces for better readability
- guard start/stop bindings so missing buttons cannot break initialization

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5a03d0888333a844a905bb376710)