### PR TITLE
Add client-only language practice app

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,397 @@
+const TARGET_LANGS = [
+  { code: 'fr', label: 'French' },
+  { code: 'en', label: 'English' },
+  { code: 'ca', label: 'Catalan' },
+  { code: 'it', label: 'Italian' },
+  { code: 'ar', label: 'Arabic (Darija friendly)' }
+];
+
+const BASE_LANGS = [
+  { code: 'en', label: 'English' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'ca', label: 'Catalan' },
+  { code: 'fr', label: 'French' },
+  { code: 'it', label: 'Italian' }
+];
+
+const STORAGE_KEY = 'speechReadingProgress';
+const DEFAULT_LESSON_SUFFIX = 'a1_introductions';
+
+const SpeechRecognition =
+  window.SpeechRecognition || window.webkitSpeechRecognition;
+
+const state = {
+  targetLang: 'fr',
+  baseLang: 'en',
+  lessonId: '',
+  sentences: [],
+  currentIndex: 0,
+  recognition: null,
+  recording: false,
+  supportsRecognition: Boolean(SpeechRecognition),
+};
+
+const els = {};
+
+document.addEventListener('DOMContentLoaded', () => {
+  cacheElements();
+  hydrateSelections();
+  attachEventListeners();
+  hydrateFromStorage();
+  updateLessonId();
+  loadLesson();
+});
+
+function cacheElements() {
+  els.targetSelect = document.getElementById('target-lang');
+  els.baseSelect = document.getElementById('base-lang');
+  els.lessonSelect = document.getElementById('lesson-select');
+  els.sentence = document.getElementById('sentence');
+  els.play = document.getElementById('play-btn');
+  els.slow = document.getElementById('slow-btn');
+  els.record = document.getElementById('record-btn');
+  els.stop = document.getElementById('stop-btn');
+  els.next = document.getElementById('next-btn');
+  els.status = document.getElementById('status');
+  els.transcript = document.getElementById('transcript');
+  els.feedback = document.getElementById('feedback');
+}
+
+function hydrateSelections() {
+  populateSelect(els.targetSelect, TARGET_LANGS, state.targetLang);
+  populateSelect(els.baseSelect, BASE_LANGS, state.baseLang);
+  populateLessonSelect();
+}
+
+function populateSelect(select, options, selected) {
+  select.innerHTML = '';
+  options.forEach((opt) => {
+    const option = document.createElement('option');
+    option.value = opt.code;
+    option.textContent = `${opt.label} (${opt.code})`;
+    if (opt.code === selected) option.selected = true;
+    select.appendChild(option);
+  });
+}
+
+function populateLessonSelect() {
+  const option = document.createElement('option');
+  option.value = `${state.targetLang}_${DEFAULT_LESSON_SUFFIX}`;
+  option.textContent = `A1 introductions (${state.targetLang})`;
+  els.lessonSelect.innerHTML = '';
+  els.lessonSelect.appendChild(option);
+}
+
+function attachEventListeners() {
+  els.targetSelect.addEventListener('change', () => {
+    state.targetLang = els.targetSelect.value;
+    populateLessonSelect();
+    updateLessonId();
+    saveProgress();
+    loadLesson();
+  });
+
+  els.baseSelect.addEventListener('change', () => {
+    state.baseLang = els.baseSelect.value;
+    saveProgress();
+    renderCurrentSentence();
+  });
+
+  els.lessonSelect.addEventListener('change', () => {
+    state.lessonId = els.lessonSelect.value;
+    state.currentIndex = 0;
+    saveProgress();
+    loadLesson();
+  });
+
+  els.play.addEventListener('click', () => speakCurrent(1));
+  els.slow.addEventListener('click', () => speakCurrent(0.7));
+  els.next.addEventListener('click', () => goToNext());
+  els.record.addEventListener('click', startRecording);
+  els.stop.addEventListener('click', stopRecording);
+
+  els.sentence.addEventListener('click', (e) => {
+    if (e.target.classList.contains('word')) {
+      e.target.classList.toggle('active');
+    }
+  });
+}
+
+function hydrateFromStorage() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return;
+  try {
+    const saved = JSON.parse(raw);
+    if (saved.targetLang) state.targetLang = saved.targetLang;
+    if (saved.baseLang) state.baseLang = saved.baseLang;
+    if (saved.lessonId) state.lessonId = saved.lessonId;
+    if (saved.progress && saved.progress[state.lessonId]) {
+      state.currentIndex = saved.progress[state.lessonId].currentIndex || 0;
+    }
+    populateSelect(els.targetSelect, TARGET_LANGS, state.targetLang);
+    populateSelect(els.baseSelect, BASE_LANGS, state.baseLang);
+    populateLessonSelect();
+  } catch (err) {
+    console.error('Failed to parse saved progress', err);
+  }
+}
+
+function saveProgress(bestScore) {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  let data = { progress: {} };
+  try {
+    data = raw ? JSON.parse(raw) : { progress: {} };
+  } catch {
+    data = { progress: {} };
+  }
+  data.targetLang = state.targetLang;
+  data.baseLang = state.baseLang;
+  data.lessonId = state.lessonId;
+  data.progress = data.progress || {};
+  data.progress[state.lessonId] = data.progress[state.lessonId] || { currentIndex: 0, scores: {} };
+  data.progress[state.lessonId].currentIndex = state.currentIndex;
+  if (bestScore !== undefined) {
+    const previous = data.progress[state.lessonId].scores?.[currentSentence().id] || 0;
+    if (!data.progress[state.lessonId].scores) data.progress[state.lessonId].scores = {};
+    data.progress[state.lessonId].scores[currentSentence().id] = Math.max(previous, bestScore);
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+function updateLessonId() {
+  state.lessonId = `${state.targetLang}_${DEFAULT_LESSON_SUFFIX}`;
+  els.lessonSelect.value = state.lessonId;
+  initRecognition();
+}
+
+async function loadLesson() {
+  const path = `data/${state.lessonId}.json`;
+  setStatus(`Loading lesson ${path}...`);
+  try {
+    const res = await fetch(path);
+    if (!res.ok) throw new Error(`Unable to load ${path}`);
+    const data = await res.json();
+    state.sentences = data.sentences || [];
+    if (!state.sentences.length) throw new Error('No sentences in lesson.');
+    const saved = loadProgressForLesson();
+    state.currentIndex = saved?.currentIndex || 0;
+    renderCurrentSentence();
+    setStatus(`Loaded ${data.lang.toUpperCase()} • ${data.level} • ${data.theme}`);
+  } catch (err) {
+    console.error(err);
+    setStatus('Could not load lesson. Please ensure the JSON exists.');
+    state.sentences = [];
+    els.sentence.textContent = '';
+  }
+}
+
+function loadProgressForLesson() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const data = JSON.parse(raw);
+    return data.progress?.[state.lessonId] || null;
+  } catch {
+    return null;
+  }
+}
+
+function renderCurrentSentence() {
+  if (!state.sentences.length) return;
+  const sentence = currentSentence();
+  els.sentence.innerHTML = '';
+  sentence.tokens.forEach((token) => {
+    const span = document.createElement('span');
+    span.textContent = token.surface + ' ';
+    span.className = 'word';
+    const translation = token.translations?.[state.baseLang] || '—';
+    span.dataset.translation = translation;
+    els.sentence.appendChild(span);
+  });
+  els.feedback.textContent = '';
+  els.transcript.textContent = '';
+  els.status.textContent = `Sentence ${state.currentIndex + 1} / ${state.sentences.length}`;
+}
+
+function currentSentence() {
+  return state.sentences[state.currentIndex];
+}
+
+function goToNext() {
+  if (!state.sentences.length) return;
+  state.currentIndex = (state.currentIndex + 1) % state.sentences.length;
+  renderCurrentSentence();
+  saveProgress();
+}
+
+function getLangCode(l2) {
+  switch (l2) {
+    case 'fr':
+      return 'fr-FR';
+    case 'en':
+      return 'en-US';
+    case 'ca':
+      return 'ca-ES';
+    case 'it':
+      return 'it-IT';
+    case 'ar':
+      return 'ar-MA';
+    default:
+      return 'en-US';
+  }
+}
+
+function speakSentence(text, langCode, rate = 1.0) {
+  const u = new SpeechSynthesisUtterance(text);
+  u.lang = langCode;
+  u.rate = rate;
+  window.speechSynthesis.cancel();
+  window.speechSynthesis.speak(u);
+}
+
+function speakCurrent(rate = 1) {
+  if (!state.sentences.length) return;
+  const text = currentSentence().text;
+  speakSentence(text, getLangCode(state.targetLang), rate);
+}
+
+function initRecognition() {
+  if (!state.supportsRecognition) return;
+  state.recognition = new SpeechRecognition();
+  state.recognition.lang = getLangCode(state.targetLang);
+  state.recognition.interimResults = false;
+  state.recognition.maxAlternatives = 1;
+  state.recognition.onresult = (event) => {
+    const transcript = event.results[0][0].transcript;
+    els.transcript.textContent = `You said: ${transcript}`;
+    handleUserTranscript(transcript);
+    state.recording = false;
+    updateRecordState();
+  };
+  state.recognition.onerror = (event) => {
+    console.error('Recognition error', event.error);
+    setStatus(`Recognition error: ${event.error}`);
+    state.recording = false;
+    updateRecordState();
+  };
+  state.recognition.onend = () => {
+    state.recording = false;
+    updateRecordState();
+  };
+  updateRecordState();
+}
+
+function startRecording() {
+  if (!state.supportsRecognition) {
+    setStatus('Speech recognition is not supported in this browser.');
+    return;
+  }
+  if (!state.recognition) initRecognition();
+  try {
+    state.recognition.start();
+    state.recording = true;
+    setStatus('Listening...');
+    updateRecordState();
+  } catch (err) {
+    console.error('Failed to start recognition', err);
+    setStatus('Could not start recording.');
+  }
+}
+
+function stopRecording() {
+  if (state.recording && state.recognition) {
+    state.recognition.stop();
+  }
+}
+
+function updateRecordState() {
+  els.record.disabled = !state.supportsRecognition || state.recording;
+  els.stop.disabled = !state.recording;
+  if (!state.supportsRecognition) {
+    els.status.textContent = 'Speech recognition not available in this browser.';
+  }
+}
+
+function normalizeText(t) {
+  return t
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}+/gu, '')
+    .replace(/[.,!?;:]/g, '')
+    .trim();
+}
+
+function tokenize(t) {
+  return normalizeText(t)
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function levenshtein(a, b) {
+  const m = a.length;
+  const n = b.length;
+  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return dp[m][n];
+}
+
+function compareTokens(targetTokens, userTokens) {
+  const statuses = [];
+  targetTokens.forEach((target, idx) => {
+    const user = userTokens[idx];
+    if (!user) {
+      statuses.push('miss');
+      return;
+    }
+    if (target === user) {
+      statuses.push('ok');
+      return;
+    }
+    const distance = levenshtein(target, user);
+    statuses.push(distance <= 1 ? 'approx' : 'miss');
+  });
+  const correctCount = statuses.filter((s) => s === 'ok').length;
+  const approxCount = statuses.filter((s) => s === 'approx').length;
+  const score = Math.round(((correctCount + approxCount * 0.5) / targetTokens.length) * 100);
+  return { statuses, score };
+}
+
+function handleUserTranscript(transcript) {
+  const targetTokens = tokenize(currentSentence().text);
+  const userTokens = tokenize(transcript);
+  const { statuses, score } = compareTokens(targetTokens, userTokens);
+  colorizeWords(statuses);
+  const message = score >= 80
+    ? 'Great!'
+    : score >= 50
+      ? 'Good, a few words need work.'
+      : "Let\'s try again. Use the slow button if needed.";
+  els.feedback.textContent = `Score: ${score}%. ${message}`;
+  saveProgress(score);
+}
+
+function colorizeWords(statuses) {
+  const spans = [...els.sentence.querySelectorAll('.word')];
+  spans.forEach((span, idx) => {
+    span.classList.remove('word-ok', 'word-approx', 'word-miss');
+    const status = statuses[idx];
+    if (status === 'ok') span.classList.add('word-ok');
+    if (status === 'approx') span.classList.add('word-approx');
+    if (status === 'miss') span.classList.add('word-miss');
+  });
+}
+
+function setStatus(text) {
+  els.status.textContent = text;
+}

--- a/data/fr_a1_introductions.json
+++ b/data/fr_a1_introductions.json
@@ -1,0 +1,83 @@
+{
+  "lang": "fr",
+  "level": "A1",
+  "theme": "introductions",
+  "sentences": [
+    {
+      "id": "fr_a1_intro_001",
+      "text": "Bonjour, je m'appelle Emma.",
+      "tokens": [
+        {
+          "surface": "Bonjour,",
+          "translations": {
+            "es": "hola",
+            "ca": "bon dia",
+            "en": "hello"
+          }
+        },
+        {
+          "surface": "je",
+          "translations": {
+            "es": "yo",
+            "ca": "jo",
+            "en": "I"
+          }
+        },
+        {
+          "surface": "m'appelle",
+          "translations": {
+            "es": "me llamo",
+            "ca": "em dic",
+            "en": "my name is"
+          }
+        },
+        {
+          "surface": "Emma.",
+          "translations": {
+            "es": "Emma",
+            "ca": "Emma",
+            "en": "Emma"
+          }
+        }
+      ]
+    },
+    {
+      "id": "fr_a1_intro_002",
+      "text": "Je viens de Paris.",
+      "tokens": [
+        {
+          "surface": "Je",
+          "translations": {
+            "es": "yo",
+            "ca": "jo",
+            "en": "I"
+          }
+        },
+        {
+          "surface": "viens",
+          "translations": {
+            "es": "vengo",
+            "ca": "vinc",
+            "en": "come"
+          }
+        },
+        {
+          "surface": "de",
+          "translations": {
+            "es": "de",
+            "ca": "de",
+            "en": "from"
+          }
+        },
+        {
+          "surface": "Paris.",
+          "translations": {
+            "es": "París",
+            "ca": "París",
+            "en": "Paris"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,1 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Speech to IPA - Browser Practice</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Language Practice (Browser Only)</h1>
+    <p class="tagline">Listen, speak, and get instant feedback without servers or paid APIs.</p>
+  </header>
 
+  <section class="settings" aria-label="Language selection">
+    <div class="field">
+      <label for="target-lang">Target language (L2):</label>
+      <select id="target-lang"></select>
+    </div>
+    <div class="field">
+      <label for="base-lang">Base language (L1):</label>
+      <select id="base-lang"></select>
+    </div>
+    <div class="field">
+      <label for="lesson-select">Lesson:</label>
+      <select id="lesson-select"></select>
+    </div>
+  </section>
+
+  <main id="app" class="card" aria-live="polite">
+    <div class="sentence" id="sentence"></div>
+    <div class="controls">
+      <button id="play-btn">▶ Play</button>
+      <button id="slow-btn">🐢 Slow</button>
+      <button id="record-btn">🎙️ Record</button>
+      <button id="stop-btn" class="secondary">⏹ Stop</button>
+      <button id="next-btn" class="secondary">Next sentence ➡</button>
+    </div>
+    <div id="status" class="status"></div>
+    <div id="transcript" class="transcript" aria-live="polite"></div>
+    <div id="feedback" class="feedback" aria-live="polite"></div>
+  </main>
+
+  <section class="notes card">
+    <h2>How this works</h2>
+    <ul>
+      <li>Everything runs in your browser using the Web Speech API.</li>
+      <li>No servers, no paid APIs, and lessons come from static JSON files.</li>
+      <li>Hover or tap words to see translations in your base language.</li>
+      <li>Your language choices and progress are stored locally in your browser.</li>
+    </ul>
+    <p class="small">Add new lessons by dropping JSON files into <code>/data</code>. The filename should follow <code>{lang}_a1_introductions.json</code> style and include <code>lang</code>, <code>level</code>, <code>theme</code>, and <code>sentences</code> fields.</p>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,209 @@
+:root {
+  --bg: #0f172a;
+  --card: #111827;
+  --text: #e5e7eb;
+  --accent: #38bdf8;
+  --muted: #9ca3af;
+  --success: #34d399;
+  --warn: #fbbf24;
+  --error: #f87171;
+  --border: #1f2937;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.12), transparent 30%),
+    radial-gradient(circle at 80% 0%, rgba(96, 165, 250, 0.14), transparent 25%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+h1 {
+  margin: 0.2rem 0;
+  font-size: 2rem;
+}
+
+.tagline {
+  color: var(--muted);
+  margin: 0;
+}
+
+.settings {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.field {
+  background: var(--card);
+  border: 1px solid var(--border);
+  padding: 0.75rem;
+  border-radius: 10px;
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+select, button {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #0b1221;
+  color: var(--text);
+  font-size: 1rem;
+}
+
+button {
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--muted);
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.25);
+}
+
+.sentence {
+  font-size: 1.35rem;
+  line-height: 1.6;
+  min-height: 64px;
+  margin-bottom: 1rem;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.status {
+  min-height: 24px;
+  color: var(--muted);
+}
+
+.transcript {
+  font-size: 0.95rem;
+  color: var(--muted);
+  min-height: 20px;
+}
+
+.feedback {
+  margin-top: 0.75rem;
+  font-weight: 600;
+}
+
+.word {
+  position: relative;
+  display: inline-block;
+  padding: 0.1rem 0.25rem;
+  border-radius: 6px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.word::after {
+  content: attr(data-translation);
+  position: absolute;
+  left: 50%;
+  bottom: 120%;
+  transform: translateX(-50%);
+  background: #111827;
+  color: var(--text);
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  transform-origin: bottom;
+  z-index: 2;
+}
+
+.word:hover::after,
+.word.active::after {
+  opacity: 1;
+  transform: translate(-50%, -4px);
+}
+
+.word-ok {
+  background: rgba(52, 211, 153, 0.12);
+  color: var(--text);
+  border-bottom: 2px solid var(--success);
+}
+
+.word-approx {
+  background: rgba(251, 191, 36, 0.16);
+  border-bottom: 2px solid var(--warn);
+}
+
+.word-miss {
+  background: rgba(248, 113, 113, 0.12);
+  border-bottom: 2px solid var(--error);
+}
+
+.notes ul {
+  padding-left: 1.25rem;
+}
+
+.notes li {
+  margin: 0.5rem 0;
+}
+
+.small {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
+
+  h1 {
+    font-size: 1.6rem;
+  }
+
+  .sentence {
+    font-size: 1.2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- create static browser-only language practice page with onboarding controls and practice loop
- implement speech synthesis/recognition, token-level translations, and local progress tracking
- add sample French introductions lesson JSON and styling for tooltips and feedback

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f68a3da7083339e6d72dce85fb97c)