### PR TITLE
Improve translation tooltip accessibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -238,7 +238,7 @@ function renderCurrentSentence() {
 
     const translation = tokenObj.translations?.[state.baseLang];
     if (translation) {
-      span.title = translation;
+      span.setAttribute('aria-label', translation);
       span.dataset.translation = translation;
     }
 


### PR DESCRIPTION
## Summary
- replace native title tooltip on word spans with an aria-label so screen readers retain translation
- keep data-translation attribute for styled tooltip behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7d51db008333b3685af0c841cf30)