### PR TITLE
Add Catalan A1 unit 2 sentences

### DIFF
--- a/data/ca_a1_introductions.json
+++ b/data/ca_a1_introductions.json
@@ -291,6 +291,328 @@
           }
         }
       ]
+    },
+    {
+      "id": "ca_a1_02_001",
+      "text": "Sóc de Romania.",
+      "tokens": [
+        {
+          "surface": "Sóc",
+          "translations": {
+            "es": "soy",
+            "en": "am",
+            "fr": "suis",
+            "it": "sono",
+            "ma": "أنا",
+            "ca": "sóc"
+          }
+        },
+        {
+          "surface": "de",
+          "translations": {
+            "es": "de",
+            "en": "from / of",
+            "fr": "de",
+            "it": "di",
+            "ma": "من",
+            "ca": "de"
+          }
+        },
+        {
+          "surface": "Romania.",
+          "translations": {
+            "es": "Rumanía",
+            "en": "Romania",
+            "fr": "Roumanie",
+            "it": "Romania",
+            "ma": "رومانيا",
+            "ca": "Romania"
+          }
+        }
+      ]
+    },
+    {
+      "id": "ca_a1_02_002",
+      "text": "Ella és de Marroc.",
+      "tokens": [
+        {
+          "surface": "Ella",
+          "translations": {
+            "es": "ella",
+            "en": "she",
+            "fr": "elle",
+            "it": "lei",
+            "ma": "هي",
+            "ca": "ella"
+          }
+        },
+        {
+          "surface": "és",
+          "translations": {
+            "es": "es",
+            "en": "is",
+            "fr": "est",
+            "it": "è",
+            "ma": "هي / هو",
+            "ca": "és"
+          }
+        },
+        {
+          "surface": "de",
+          "translations": {
+            "es": "de",
+            "en": "from / of",
+            "fr": "de",
+            "it": "di",
+            "ma": "من",
+            "ca": "de"
+          }
+        },
+        {
+          "surface": "Marroc.",
+          "translations": {
+            "es": "Marruecos",
+            "en": "Morocco",
+            "fr": "Maroc",
+            "it": "Marocco",
+            "ma": "المغرب",
+            "ca": "Marroc"
+          }
+        }
+      ]
+    },
+    {
+      "id": "ca_a1_02_003",
+      "text": "Parlo àrab i una mica de castellà.",
+      "tokens": [
+        {
+          "surface": "Parlo",
+          "translations": {
+            "es": "hablo",
+            "en": "I speak",
+            "fr": "je parle",
+            "it": "parlo",
+            "ma": "كنهضر",
+            "ca": "parlo"
+          }
+        },
+        {
+          "surface": "àrab",
+          "translations": {
+            "es": "árabe",
+            "en": "Arabic",
+            "fr": "arabe",
+            "it": "arabo",
+            "ma": "العربية",
+            "ca": "àrab"
+          }
+        },
+        {
+          "surface": "i",
+          "translations": {
+            "es": "y",
+            "en": "and",
+            "fr": "et",
+            "it": "e",
+            "ma": "و",
+            "ca": "i"
+          }
+        },
+        {
+          "surface": "una",
+          "translations": {
+            "es": "una",
+            "en": "a (f.)",
+            "fr": "une",
+            "it": "una",
+            "ma": "واحدة",
+            "ca": "una"
+          }
+        },
+        {
+          "surface": "mica",
+          "translations": {
+            "es": "poco",
+            "en": "a little",
+            "fr": "un peu",
+            "it": "un po'",
+            "ma": "شوية",
+            "ca": "mica"
+          }
+        },
+        {
+          "surface": "de",
+          "translations": {
+            "es": "de",
+            "en": "of",
+            "fr": "de",
+            "it": "di",
+            "ma": "ديال",
+            "ca": "de"
+          }
+        },
+        {
+          "surface": "castellà.",
+          "translations": {
+            "es": "castellano",
+            "en": "Spanish",
+            "fr": "espagnol",
+            "it": "spagnolo",
+            "ma": "الإسبانية",
+            "ca": "castellà"
+          }
+        }
+      ]
+    },
+    {
+      "id": "ca_a1_02_004",
+      "text": "A casa parlem amazic.",
+      "tokens": [
+        {
+          "surface": "A",
+          "translations": {
+            "es": "en",
+            "en": "at / in",
+            "fr": "à",
+            "it": "a",
+            "ma": "فـ",
+            "ca": "a"
+          }
+        },
+        {
+          "surface": "casa",
+          "translations": {
+            "es": "casa",
+            "en": "home",
+            "fr": "maison",
+            "it": "casa",
+            "ma": "الدار",
+            "ca": "casa"
+          }
+        },
+        {
+          "surface": "parlem",
+          "translations": {
+            "es": "hablamos",
+            "en": "we speak",
+            "fr": "nous parlons",
+            "it": "parliamo",
+            "ma": "كنهضرو",
+            "ca": "parlem"
+          }
+        },
+        {
+          "surface": "amazic.",
+          "translations": {
+            "es": "amazigh",
+            "en": "Amazigh",
+            "fr": "amazigh",
+            "it": "amazigh",
+            "ma": "تامازيغت",
+            "ca": "amazic"
+          }
+        }
+      ]
+    },
+    {
+      "id": "ca_a1_02_005",
+      "text": "Vull aprendre català.",
+      "tokens": [
+        {
+          "surface": "Vull",
+          "translations": {
+            "es": "quiero",
+            "en": "I want",
+            "fr": "je veux",
+            "it": "voglio",
+            "ma": "بغيت",
+            "ca": "vull"
+          }
+        },
+        {
+          "surface": "aprendre",
+          "translations": {
+            "es": "aprender",
+            "en": "to learn",
+            "fr": "apprendre",
+            "it": "imparare",
+            "ma": "نتعلم",
+            "ca": "aprendre"
+          }
+        },
+        {
+          "surface": "català.",
+          "translations": {
+            "es": "catalán",
+            "en": "Catalan",
+            "fr": "catalan",
+            "it": "catalano",
+            "ma": "الكتالان",
+            "ca": "català"
+          }
+        }
+      ]
+    },
+    {
+      "id": "ca_a1_02_006",
+      "text": "A l'institut parlem en català.",
+      "tokens": [
+        {
+          "surface": "A",
+          "translations": {
+            "es": "en",
+            "en": "at / in",
+            "fr": "à",
+            "it": "a",
+            "ma": "فـ",
+            "ca": "a"
+          }
+        },
+        {
+          "surface": "l'institut",
+          "translations": {
+            "es": "el instituto",
+            "en": "the school",
+            "fr": "le collège",
+            "it": "la scuola / l'istituto",
+            "ma": "المدرسة",
+            "ca": "l'institut"
+          }
+        },
+        {
+          "surface": "parlem",
+          "translations": {
+            "es": "hablamos",
+            "en": "we speak",
+            "fr": "nous parlons",
+            "it": "parliamo",
+            "ma": "كنهضرو",
+            "ca": "parlem"
+          }
+        },
+        {
+          "surface": "en",
+          "translations": {
+            "es": "en",
+            "en": "in",
+            "fr": "en",
+            "it": "in",
+            "ma": "بـ",
+            "ca": "en"
+          }
+        },
+        {
+          "surface": "català.",
+          "translations": {
+            "es": "catalán",
+            "en": "Catalan",
+            "fr": "catalan",
+            "it": "catalano",
+            "ma": "الكتالان",
+            "ca": "català"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add Catalan A1 unit 2 sentences covering origins, languages, and learning
- provide translations across Spanish, English, French, Italian, and Moroccan Darija

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7e50f3748333956f9719d4a9cdb3)