### PR TITLE
Fix Catalan lesson wiring and rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -231,6 +231,7 @@ async function loadLesson() {
     if (!res.ok) throw new Error(`Unable to load ${path}`);
     const data = await res.json();
     state.sentences = data.sentences || [];
+    console.log('Loaded lesson', path, 'sentences:', state.sentences.length);
     if (!state.sentences.length) throw new Error('No sentences in lesson.');
     const saved = loadProgressForLesson();
     state.currentIndex = saved?.currentIndex || 0;
@@ -259,15 +260,36 @@ function renderCurrentSentence() {
   if (!state.sentences.length) return;
   const sentence = currentSentence();
   const sentenceEl = els.sentence;
+
   sentenceEl.innerHTML = '';
   wordSpans = [];
-  currentSentenceText = sentence.text;
-  targetTokens = tokenizeText(currentSentenceText);
 
-  sentence.tokens.forEach((tokenObj) => {
+  const fullText = sentence.text || '';
+  currentSentenceText = fullText;
+
+  const hasTokens = Array.isArray(sentence.tokens) && sentence.tokens.length > 0;
+
+  let tokensToRender;
+  if (hasTokens) {
+    tokensToRender = sentence.tokens.map((tokenObj) => ({
+      surface: tokenObj.surface || tokenObj.text || '',
+      translations: tokenObj.translations || {},
+      latin: tokenObj.latin,
+    }));
+    targetTokens = tokenizeText(fullText);
+  } else {
+    const rawTokens = fullText.split(/\s+/).filter(Boolean);
+    tokensToRender = rawTokens.map((word) => ({
+      surface: word,
+      translations: {},
+    }));
+    targetTokens = rawTokens.map((w) => normalizeWord(w));
+  }
+
+  tokensToRender.forEach((tokenObj) => {
     const span = document.createElement('span');
-    const spokenWord = tokenObj.surface || tokenObj.text || '';
-    span.textContent = `${spokenWord} `;
+    const spokenWord = tokenObj.surface || '';
+    span.textContent = spokenWord + ' ';
     span.classList.add('word', 'word-pending');
     span.dataset.word = spokenWord;
 

--- a/data/lessons.json
+++ b/data/lessons.json
@@ -1,7 +1,14 @@
 {
   "lessons": [
-    { "id": "fr_a1_introductions", "lang": "fr", "label": "A1 introductions" },
-    { "id": "ca_a1.1_introductions", "lang": "ca", "label": "A1.1 introductions" },
-    { "id": "ca_a1.2_introductions", "lang": "ca", "label": "A1.2 introductions" }
+    {
+      "id": "fr_a1_introductions",
+      "lang": "fr",
+      "label": "French A1 · Introductions"
+    },
+    {
+      "id": "ca_a1_course",
+      "lang": "ca",
+      "label": "Catalan A1 · Course"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- point Catalan lesson manifest entry to ca_a1_course.json and keep French listing
- log lesson load counts and handle sentences without token data when rendering
- ensure Catalan sentences display by splitting text into words when tokens are missing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f8c40c88c833383e8843c97751163)