### PR TITLE
Add custom sentence practice mode and UI controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,9 @@ const state = {
   lessonId: '',
   sentences: [],
   currentIndex: 0,
+  mode: 'lesson',
+  customSentence: '',
+  savedLessonState: null,
   recognition: null,
   recording: false,
   supportsRecognition: Boolean(SpeechRecognition),
@@ -168,6 +171,9 @@ function cacheElements() {
   els.status = document.getElementById('status');
   els.transcript = document.getElementById('transcript');
   els.feedback = document.getElementById('feedback');
+  els.customInput = document.getElementById('custom-sentence');
+  els.customSubmit = document.getElementById('custom-submit');
+  els.customReset = document.getElementById('custom-reset');
 }
 
 function createTooltips() {
@@ -288,6 +294,10 @@ function attachEventListeners() {
   });
 
   els.lessonSelect.addEventListener('change', () => {
+    if (state.mode === 'custom') {
+      state.mode = 'lesson';
+      state.savedLessonState = null;
+    }
     state.lessonId = els.lessonSelect.value;
     state.currentIndex = 0;
     saveProgress();
@@ -309,6 +319,22 @@ function attachEventListeners() {
 
   els.sentence.addEventListener('mousemove', onSentenceMouseMove);
   els.sentence.addEventListener('mouseleave', hideTooltips);
+
+  els.customSubmit.addEventListener('click', (e) => {
+    e.preventDefault();
+    const text = (els.customInput.value || '').trim();
+    if (!text) {
+      setStatus('Please enter a sentence to practice.');
+      return;
+    }
+    state.customSentence = text;
+    enterCustomMode(text);
+  });
+
+  els.customReset.addEventListener('click', (e) => {
+    e.preventDefault();
+    exitCustomMode();
+  });
 }
 
 function hydrateFromStorage() {
@@ -349,6 +375,7 @@ function normalizeLegacyCodes(saved) {
 }
 
 function saveProgress(bestScore) {
+  if (state.mode === 'custom') return;
   const raw = localStorage.getItem(STORAGE_KEY);
   let data = { progress: {} };
   try {
@@ -376,6 +403,8 @@ function updateLessonId() {
 }
 
 async function loadLesson() {
+  state.mode = 'lesson';
+  state.savedLessonState = null;
   const lang = state.targetLang;
   const lessonId = state.lessonId;
   if (!lessonId) return;
@@ -664,7 +693,12 @@ function renderCurrentSentence() {
   resetSentenceState();
   els.feedback.textContent = '';
   els.transcript.textContent = '';
-  els.status.textContent = `Sentence ${state.currentIndex + 1} / ${state.sentences.length}`;
+
+  const total = state.sentences.length;
+  els.status.textContent =
+    state.mode === 'custom'
+      ? 'Custom sentence practice'
+      : `Sentence ${state.currentIndex + 1} / ${total}`;
 }
 
 function currentSentence() {
@@ -676,6 +710,57 @@ function goToNext() {
   state.currentIndex = (state.currentIndex + 1) % state.sentences.length;
   renderCurrentSentence();
   saveProgress();
+}
+
+function enterCustomMode(text) {
+  if (!text) return;
+
+  if (state.mode !== 'custom') {
+    state.savedLessonState = {
+      sentences: state.sentences.slice(),
+      currentIndex: state.currentIndex,
+      lessonId: state.lessonId,
+    };
+  }
+
+  state.mode = 'custom';
+  state.currentIndex = 0;
+  state.sentences = [
+    {
+      id: 'custom',
+      unit: null,
+      theme: 'Custom practice',
+      title: 'Custom practice',
+      sentenceNumber: 1,
+      text,
+      translations: { [state.baseLang]: text },
+      tokens: [],
+    },
+  ];
+
+  renderCurrentSentence();
+  setStatus('Practicing your custom sentence.');
+}
+
+function exitCustomMode() {
+  if (state.mode !== 'custom') return;
+
+  state.mode = 'lesson';
+  const saved = state.savedLessonState;
+  state.savedLessonState = null;
+
+  if (saved && saved.sentences?.length) {
+    state.lessonId = saved.lessonId || state.lessonId;
+    state.sentences = saved.sentences;
+    state.currentIndex = saved.currentIndex || 0;
+    populateLessonSelect();
+    els.lessonSelect.value = state.lessonId;
+    renderCurrentSentence();
+    setStatus('Back to lesson mode.');
+    return;
+  }
+
+  loadLesson();
 }
 
 function getLangCode(l2) {

--- a/index.html
+++ b/index.html
@@ -25,6 +25,20 @@
       <label for="lesson-select">Lesson:</label>
       <select id="lesson-select"></select>
     </div>
+    <div class="field custom-field">
+      <label for="custom-sentence">Custom practice</label>
+      <textarea
+        id="custom-sentence"
+        rows="3"
+        placeholder="Type or paste a sentence to practice"
+        aria-label="Custom sentence input"
+      ></textarea>
+      <div class="custom-actions">
+        <button id="custom-submit">Practice this sentence</button>
+        <button id="custom-reset" class="secondary">Back to lessons</button>
+      </div>
+      <p class="small">Submit a custom sentence without losing your lesson progress.</p>
+    </div>
   </section>
 
   <main id="app" class="card" aria-live="polite">

--- a/styles.css
+++ b/styles.css
@@ -60,7 +60,7 @@ label {
   margin-bottom: 0.35rem;
 }
 
-select, button {
+select, button, textarea {
   width: 100%;
   padding: 0.65rem 0.75rem;
   border-radius: 8px;
@@ -90,6 +90,25 @@ button:disabled {
 button.secondary {
   background: transparent;
   color: var(--muted);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 96px;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.custom-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.custom-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.5rem;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- add a custom practice textarea and controls alongside lesson selections
- introduce a custom practice mode that builds a pseudo-lesson without affecting saved lesson progress
- update styling to match existing field and card layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694021fd0b0c833382054d827e0f818b)