### PR TITLE
Default to custom text lesson

### DIFF
--- a/app.js
+++ b/app.js
@@ -254,7 +254,8 @@ function populateLessonSelect() {
   });
 
   const hasSelection = options.some((lesson) => lesson.id === state.lessonId);
-  const defaultLessonId = getDefaultLessonId();
+  const defaultLessonId = hasSelection ? state.lessonId : CUSTOM_LESSON_ID;
+  const fallbackLessonId = getDefaultLessonId();
 
   state.lessonId = hasSelection ? state.lessonId : defaultLessonId;
   els.lessonSelect.value = state.lessonId;
@@ -262,7 +263,7 @@ function populateLessonSelect() {
   if (state.lessonId !== CUSTOM_LESSON_ID) {
     lastLessonId = state.lessonId;
   } else if (!lastLessonId) {
-    lastLessonId = defaultLessonId;
+    lastLessonId = fallbackLessonId;
   }
 }
 


### PR DESCRIPTION
## Summary
- default the lesson selector to the custom text entry so it always appears first
- keep the prior lesson as a fallback when leaving custom mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694030ed16c88333bb8aa767783fc973)