### PR TITLE
Fix default lesson selection and custom modal reset

### DIFF
--- a/app.js
+++ b/app.js
@@ -254,10 +254,10 @@ function populateLessonSelect() {
   });
 
   const hasSelection = options.some((lesson) => lesson.id === state.lessonId);
-  const defaultLessonId = hasSelection ? state.lessonId : CUSTOM_LESSON_ID;
   const fallbackLessonId = getDefaultLessonId();
+  const nextLessonId = hasSelection ? state.lessonId : fallbackLessonId;
 
-  state.lessonId = hasSelection ? state.lessonId : defaultLessonId;
+  state.lessonId = nextLessonId;
   els.lessonSelect.value = state.lessonId;
 
   if (state.lessonId !== CUSTOM_LESSON_ID) {
@@ -405,8 +405,12 @@ function closeCustomModal(resetSelection = false) {
   els.customModal.classList.add('hidden');
   els.customModal.setAttribute('aria-hidden', 'true');
 
-  if (resetSelection && state.mode !== 'custom') {
-    els.lessonSelect.value = state.lessonId || lastLessonId || getDefaultLessonId();
+  if (resetSelection) {
+    const fallbackLessonId = lastLessonId || getDefaultLessonId();
+    els.lessonSelect.value = fallbackLessonId;
+    if (state.mode !== 'custom') {
+      state.lessonId = fallbackLessonId;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- default lesson selection now uses the language's fallback lesson and updates lastLessonId accordingly
- closing the custom modal with reset restores the select and lesson state to the last real lesson
- keep custom modal opening only when explicitly chosen

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694035df109c8333ab87a02cd6a5c84c)