### PR TITLE
Ensure custom modal buttons close dialog

### DIFF
--- a/app.js
+++ b/app.js
@@ -353,11 +353,15 @@ function attachEventListeners() {
     }
     state.customSentence = text;
     enterCustomMode(text);
+    closeCustomModal();
   });
 
   els.customReset.addEventListener('click', (e) => {
     e.preventDefault();
     closeCustomModal(true);
+    if (!state.customSentence) {
+      els.customInput.value = '';
+    }
   });
 
   if (els.customBackdrop) {


### PR DESCRIPTION
## Summary
- ensure the custom practice modal closes after submitting a sentence
- keep the cancel action hiding the modal while clearing the input when unused

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69403a21689c833380f6c78fbd974ded)