### PR TITLE
Add close control for custom text modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -177,7 +177,7 @@ function cacheElements() {
   els.customSubmit = document.getElementById('custom-submit');
   els.customReset = document.getElementById('custom-reset');
   els.customModal = document.getElementById('custom-modal');
-  els.customBackdrop = document.querySelector('[data-close-modal]');
+  els.customDismissButtons = Array.from(document.querySelectorAll('[data-close-modal]'));
 }
 
 function createTooltips() {
@@ -371,9 +371,9 @@ function attachEventListeners() {
     }
   });
 
-  if (els.customBackdrop) {
-    els.customBackdrop.addEventListener('click', () => closeCustomModal(true));
-  }
+  (els.customDismissButtons || []).forEach((btn) => {
+    btn.addEventListener('click', () => closeCustomModal(true));
+  });
 
   document.addEventListener('keydown', (event) => {
     if (event.key === 'Escape' && els.customModal && !els.customModal.classList.contains('hidden')) {

--- a/index.html
+++ b/index.html
@@ -44,6 +44,9 @@
   <div id="custom-modal" class="modal hidden" aria-hidden="true">
     <div class="modal-backdrop" data-close-modal></div>
     <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="custom-modal-title">
+      <button class="modal-close" type="button" data-close-modal aria-label="Close custom text dialog">
+        ✕
+      </button>
       <h2 id="custom-modal-title">Practice custom text</h2>
       <p class="small">Use your own text without losing your lesson progress.</p>
 

--- a/styles.css
+++ b/styles.css
@@ -142,6 +142,30 @@ textarea {
   z-index: 1;
 }
 
+.modal-close {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  width: 2.25rem;
+  height: 2.25rem;
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.modal-close:hover,
+.modal-close:focus-visible {
+  background: rgba(0, 0, 0, 0.06);
+  border-color: var(--border);
+  outline: none;
+  transform: scale(1.05);
+}
+
 .modal h2 {
   margin: 0 0 0.35rem;
 }


### PR DESCRIPTION
## Summary
- add an explicit close button to the custom text modal
- wire all modal dismiss targets to share the same close handler
- style the modal close control for accessibility and visibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694040f1d5a08333a10ee9f2030833e0)