### PR TITLE
Reorder language options in dropdowns

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,18 +1,18 @@
 const TARGET_LANGS = [
-  { code: 'fr', label: 'French' },
   { code: 'en', label: 'English' },
+  { code: 'fr', label: 'French' },
   { code: 'ca', label: 'Catalan' },
-  { code: 'it', label: 'Italian' },
-  { code: 'ma', label: 'Moroccan Darija' }
+  { code: 'ma', label: 'Moroccan Darija' },
+  { code: 'it', label: 'Italian' }
 ];
 
 const BASE_LANGS = [
-  { code: 'en', label: 'English' },
-  { code: 'es', label: 'Spanish' },
   { code: 'ca', label: 'Catalan' },
+  { code: 'en', label: 'English' },
   { code: 'fr', label: 'French' },
-  { code: 'it', label: 'Italian' },
-  { code: 'ma', label: 'Moroccan Darija' }
+  { code: 'es', label: 'Spanish' },
+  { code: 'ma', label: 'Moroccan Darija' },
+  { code: 'it', label: 'Italian' }
 ];
 
 const STORAGE_KEY = 'speechReadingProgress';


### PR DESCRIPTION
## Summary
- reorder target language dropdown to English, French, Catalan, Moroccan Darija, Italian
- reorder base language dropdown to Catalan, English, French, Spanish, Moroccan Darija, Italian

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940464ac9648333bd9ef8d98b96aee6)