### PR TITLE
Improve repeat filtering and add tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,9 +32,11 @@ const MASTER_ROWS_BY_LANG = {};
 const TRANSLATION_LANG_CODES = ['ca', 'es', 'en', 'fr', 'it', 'ma'];
 
 const SpeechRecognition =
-  window.SpeechRecognition || window.webkitSpeechRecognition;
+  typeof window !== 'undefined'
+    ? window.SpeechRecognition || window.webkitSpeechRecognition
+    : null;
 
-if (window.speechSynthesis) {
+if (typeof window !== 'undefined' && window.speechSynthesis) {
   window.speechSynthesis.onvoiceschanged = () => {
     window.speechSynthesis.getVoices();
     warnIfArabicVoiceMissing();
@@ -148,17 +150,19 @@ async function ensureMasterRowsForLang(lang) {
   return rows;
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
-  cacheElements();
-  createTooltips();
-  hydrateSelections();
-  attachEventListeners();
-  hydrateFromStorage();
-  await loadLessonManifest();
-  updateLessonId();
-  loadLesson();
-  warnIfArabicVoiceMissing();
-});
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', async () => {
+    cacheElements();
+    createTooltips();
+    hydrateSelections();
+    attachEventListeners();
+    hydrateFromStorage();
+    await loadLessonManifest();
+    updateLessonId();
+    loadLesson();
+    warnIfArabicVoiceMissing();
+  });
+}
 
 function cacheElements() {
   els.targetSelect = document.getElementById('target-lang');
@@ -1079,9 +1083,16 @@ function buildMaxConsecutiveRuns(tokens) {
 
 function filterUnexpectedRepeats(transcript, targetTokensForSentence) {
   const spokenTokens = tokenizeText(transcript);
-  const allowedRuns = buildMaxConsecutiveRuns(targetTokensForSentence || []);
+  const targetTokensNormalized = targetTokensForSentence || [];
+  const allowedRuns = buildMaxConsecutiveRuns(targetTokensNormalized);
+  const allowedCounts = new Map();
+
+  targetTokensNormalized.forEach((token) => {
+    allowedCounts.set(token, (allowedCounts.get(token) || 0) + 1);
+  });
 
   const filteredTokens = [];
+  const seenCounts = new Map();
   let prev = null;
   let runLength = 0;
 
@@ -1093,10 +1104,19 @@ function filterUnexpectedRepeats(transcript, targetTokensForSentence) {
       runLength = 1;
     }
 
-    const allowed = allowedRuns.get(token) || 1;
-    if (runLength <= allowed) {
-      filteredTokens.push(token);
+    const allowedRun = allowedRuns.get(token) || 1;
+    if (runLength > allowedRun) {
+      return;
     }
+
+    const allowedTotal = allowedCounts.has(token) ? allowedCounts.get(token) : 1;
+    const seen = seenCounts.get(token) || 0;
+    if (seen >= allowedTotal) {
+      return;
+    }
+
+    seenCounts.set(token, seen + 1);
+    filteredTokens.push(token);
   });
 
   return {
@@ -1297,4 +1317,12 @@ function finalizeScore(transcript) {
 
 function setStatus(text) {
   els.status.textContent = text;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    tokenizeText,
+    buildMaxConsecutiveRuns,
+    filterUnexpectedRepeats,
+  };
 }

--- a/app.test.js
+++ b/app.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  filterUnexpectedRepeats,
+  tokenizeText,
+} = require('./app.js');
+
+test('drops repeated sequences once expected counts are met', () => {
+  const targetTokens = tokenizeText('hi my name is marc');
+  const spoken = 'hi my hi my hi my name is marc';
+
+  const { filteredTokens } = filterUnexpectedRepeats(spoken, targetTokens);
+
+  assert.deepStrictEqual(filteredTokens, tokenizeText('hi my name is marc'));
+});
+
+test('keeps legitimate consecutive duplicates but trims extras', () => {
+  const targetTokens = tokenizeText('very very good job');
+  const spoken = 'very very very good job';
+
+  const { filteredTokens } = filterUnexpectedRepeats(spoken, targetTokens);
+
+  assert.deepStrictEqual(filteredTokens, tokenizeText('very very good job'));
+});
+
+test('removes extra occurrences even when they are not consecutive', () => {
+  const targetTokens = tokenizeText('to be or not to be');
+  const spoken = 'to be or not to be to be';
+
+  const { filteredTokens } = filterUnexpectedRepeats(spoken, targetTokens);
+
+  assert.deepStrictEqual(filteredTokens, tokenizeText('to be or not to be'));
+});


### PR DESCRIPTION
## Summary
- collapse unexpected repeated tokens using per-token expected counts while keeping legitimate consecutive duplicates
- guard browser-only initialization to allow importing utilities for tests
- add node-based tests covering deduplication and expected duplicate handling

## Testing
- node --test app.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694906928cc08333a8ffea1a1d11e048)