### PR TITLE
Add Google Translate as default TTS fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Open `index.html` in a modern browser or serve the folder with any static file s
 
 ## Text-to-speech (TTS) fallback service
 
-The app first prefers the browser's built-in speech synthesis. If the browser lacks a locale-appropriate voice or does not support speech synthesis, it can fall back to a lightweight HTTP TTS service. Configure the base URL in one of these ways:
+The app first prefers the browser's built-in speech synthesis. If the browser lacks a locale-appropriate voice or does not support speech synthesis, it automatically falls back to a lightweight HTTP TTS service. Speed and responsiveness are prioritized over premium audio quality.
+
+### Default service
+By default, the app uses Google's free Translate TTS endpoint (`https://translate.googleapis.com/translate_tts`). No sign-up or API key is required. The `lang` parameter is derived from the target language (e.g. `fr` or `en`), and the endpoint returns an audio payload such as `audio/mpeg`.
+
+### Override the service URL
+If you want to point to a different service (must expose `GET /tts?text=...&lang=...`), configure the base URL in one of these ways:
 
 1. Add a meta tag in `index.html`:
    ```html

--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ const DEFAULT_LESSON_SUFFIX = 'a1_introductions';
 let availableLessons = [];
 const CUSTOM_LESSON_ID = 'custom';
 const VOICE_STORAGE_KEY = 'speechtoipa-voices';
+const DEFAULT_TTS_BASE_URL = 'https://translate.googleapis.com';
 
 const MASTER_CSV_URLS = {
   ca: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQl1GNJGHAilkpQn3KiB0HnrUGEXSQp_dwo6A548izQXL-iAtAIHB2g3_o6VYAOv6UFuUOcISzJQO61/pub?gid=1216373156&single=true&output=csv',
@@ -33,7 +34,7 @@ const MASTER_ROWS_BY_LANG = {};
 const TRANSLATION_LANG_CODES = ['ca', 'es', 'en', 'fr', 'it', 'ma'];
 
 const NO_TTS_SUPPORT_MESSAGE =
-  'No local text-to-speech voice found. Configure a TTS service for fallback playback.';
+  'No local text-to-speech voice found. Using fallback TTS service for playback.';
 
 const TTS_CACHE_PREFIX = 'speechtoipa-tts:';
 const TTS_LOCAL_CACHE_CHAR_LIMIT = 180;
@@ -53,7 +54,7 @@ const SpeechRecognition =
     : null;
 
 function getTtsBaseUrl() {
-  if (typeof window === 'undefined') return '';
+  if (typeof window === 'undefined') return DEFAULT_TTS_BASE_URL;
   if (window.TTS_BASE_URL) return window.TTS_BASE_URL.replace(/\/$/, '');
   if (window.__TTS_BASE_URL__) return window.__TTS_BASE_URL__.replace(/\/$/, '');
 
@@ -64,7 +65,27 @@ function getTtsBaseUrl() {
     }
   }
 
-  return '';
+  return DEFAULT_TTS_BASE_URL;
+}
+
+function isGoogleTranslateTts(baseUrl) {
+  return /translate\.googleapis\.com/i.test(baseUrl || '');
+}
+
+function buildTtsRequestUrl(baseUrl, text, langCode) {
+  const sanitizedBase = (baseUrl || '').replace(/\/$/, '');
+  if (isGoogleTranslateTts(sanitizedBase)) {
+    const googleLang = (langCode || '').split('-')[0] || langCode || 'en';
+    const params = new URLSearchParams({
+      ie: 'UTF-8',
+      q: text,
+      tl: googleLang,
+      client: 'gtx',
+    });
+    return `${sanitizedBase}/translate_tts?${params.toString()}`;
+  }
+
+  return `${sanitizedBase}/tts?text=${encodeURIComponent(text)}&lang=${encodeURIComponent(langCode)}`;
 }
 
 function getTtsCacheKey(text, lang) {
@@ -210,7 +231,7 @@ async function fetchTtsAudio(text, langCode) {
   setTtsLoading(true);
   setStatus('Fetching audio from TTS service…');
   try {
-    const url = `${baseUrl}/tts?text=${encodeURIComponent(text)}&lang=${encodeURIComponent(langCode)}`;
+    const url = buildTtsRequestUrl(baseUrl, text, langCode);
     const res = await fetch(url);
     if (!res.ok) {
       throw new Error(`TTS service returned ${res.status}`);

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Optional: set a TTS fallback service base URL -->
+  <!-- Optional: override the TTS fallback service base URL (defaults to translate.googleapis.com) -->
   <!-- <meta name="tts-base-url" content="https://your-tts-service.example.com"> -->
   <title>Read • Listen • Speak</title>
   <link rel="stylesheet" href="styles.css" />


### PR DESCRIPTION
## Summary
- default the fallback TTS service to Google Translate for fast, free playback
- build TTS request URLs that support the Google Translate endpoint while keeping custom services compatible
- document the default service and how to override it in the HTML and README

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694963cf2b308333bf992c4378e97f9e)