### PR TITLE
Reset voice warmups when voice selection changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -714,6 +714,7 @@ function attachEventListeners() {
 
   els.voiceSelect?.addEventListener('change', () => {
     voiceSelections[state.targetLang] = els.voiceSelect.value;
+    playbackQueue.resetWarmup(getLangCode(state.targetLang));
     persistVoices();
     updateVoiceNote();
     updatePlaybackWarnings();
@@ -1393,6 +1394,14 @@ function createPlaybackQueue() {
     return promise;
   }
 
+  function resetWarmup(langCode) {
+    if (!langCode) {
+      warmups.clear();
+      return;
+    }
+    warmups.delete(langCode);
+  }
+
   async function waitForSynthAvailability() {
     const synth = window.speechSynthesis;
     if (!synth) return;
@@ -1493,6 +1502,7 @@ function createPlaybackQueue() {
       processQueue();
     },
     warmVoicesForLang,
+    resetWarmup,
     isWarming() {
       return isWarming;
     },


### PR DESCRIPTION
### Motivation
- Changing the selected voice did not clear the cached warmup for the active language, so `getVoiceForLang()` could continue returning the previously resolved voice instead of the newly selected one.

### Description
- Add `resetWarmup(langCode)` inside `createPlaybackQueue()` to delete the warmup entry for a language or clear all entries when no `langCode` is provided.
- Expose `resetWarmup` on the playback queue return object so callers can clear the cache (`resetWarmup`, `warmVoicesForLang` are now available).
- Call `playbackQueue.resetWarmup(getLangCode(state.targetLang))` in the `els.voiceSelect` change handler immediately after updating `voiceSelections[state.targetLang]` so the next playback re-resolves the selected voice.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a067f0aac8333bbe726119d3c6c3a)