### PR TITLE
Spacebar toggles recording (start/stop)

### DIFF
--- a/app.js
+++ b/app.js
@@ -700,7 +700,9 @@ function attachEventListeners() {
 
     if (event.key === ' ' || event.code === 'Space') {
       event.preventDefault();
-      if (!state.recording) {
+      if (state.recording) {
+        stopRecording();
+      } else {
         startRecording();
       }
       return;


### PR DESCRIPTION
### Motivation
- Allow the spacebar hotkey to both start and stop speech recognition so users can toggle recording with a single key.

### Description
- Update the `keydown` handler in `attachEventListeners` to call `stopRecording()` when `state.recording` is true and `startRecording()` otherwise, preserving `event.preventDefault()` for the space key.
- This change modifies the block handling `if (event.key === ' ' || event.code === 'Space')` in `app.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a0ad8edbc8333a77570b9977da2e8)