### PR TITLE
Normalize digit tokens like number words

### DIFF
--- a/app.js
+++ b/app.js
@@ -1212,7 +1212,7 @@ function renderCurrentSentence() {
     }
   } else {
     const rawTokens = fullText.split(/\s+/).filter(Boolean);
-    targetTokens = rawTokens.map((w) => normalizeWord(w));
+    targetTokens = rawTokens.map((w) => normalizeToken(w));
 
     rawTokens.forEach((word) => {
       const span = document.createElement('span');
@@ -1824,9 +1824,38 @@ function normalizeWord(w) {
     .trim();
 }
 
+const NUMBER_TOKEN_MAP = new Map([
+  ['zero', '0'],
+  ['one', '1'],
+  ['two', '2'],
+  ['three', '3'],
+  ['four', '4'],
+  ['five', '5'],
+  ['six', '6'],
+  ['seven', '7'],
+  ['eight', '8'],
+  ['nine', '9'],
+  ['ten', '10'],
+]);
+
+const DIGIT_TOKEN_PATTERN = /^\d+$/;
+
+function normalizeToken(rawToken) {
+  const token = normalizeWord(rawToken);
+  if (!token) return '';
+  if (NUMBER_TOKEN_MAP.has(token)) {
+    return NUMBER_TOKEN_MAP.get(token);
+  }
+  if (DIGIT_TOKEN_PATTERN.test(token)) {
+    return token;
+  }
+  return token;
+}
+
 function tokenizeText(t) {
   return normalizeWord(t)
     .split(/\s+/)
+    .map((token) => normalizeToken(token))
     .filter(Boolean);
 }
 
@@ -1964,8 +1993,8 @@ function passesApproximationRule(target, candidate, langCode) {
 }
 
 function similarityScore(rawTarget, rawCandidate, langCode) {
-  const target = normalizeWord(rawTarget);
-  const cand = normalizeWord(rawCandidate);
+  const target = normalizeToken(rawTarget);
+  const cand = normalizeToken(rawCandidate);
   if (!target || !cand) return 0;
 
   if (target === cand) return 1;

--- a/app.test.js
+++ b/app.test.js
@@ -32,3 +32,14 @@ test('removes extra occurrences even when they are not consecutive', () => {
 
   assert.deepStrictEqual(filteredTokens, tokenizeText('to be or not to be'));
 });
+
+test('normalizes digit tokens to match spelled-out numbers', () => {
+  const spelled = tokenizeText('I have two apples');
+  const digits = tokenizeText('I have 2 apples');
+
+  assert.deepStrictEqual(digits, spelled);
+});
+
+test('tokenizes digit sequences as number tokens', () => {
+  assert.deepStrictEqual(tokenizeText('1 2 3 4 5'), ['1', '2', '3', '4', '5']);
+});


### PR DESCRIPTION
### Motivation
- Tokenization and matching only normalized spelled-out numbers, causing digit inputs like `1`/`2` to be treated differently from `one`/`two` and potentially break matching and scoring.
- Make number handling consistent by mapping spelled-out numbers and raw digit sequences to a common internal representation so downstream matching and validation treat them equivalently.

### Description
- Added a `NUMBER_TOKEN_MAP` and `DIGIT_TOKEN_PATTERN` and implemented `normalizeToken(rawToken)` to map spelled-out numbers to digits and accept digit tokens as-is in `app.js`.
- Updated `tokenizeText` to call `normalizeToken` for each token and applied `normalizeToken` when building `targetTokens` for free-form sentences and inside `similarityScore` to ensure comparisons use the normalized form.
- Updated UI token prep to use the normalized token values while leaving displayed text untouched by keeping spans' `textContent` as the original word.
- Modified `app.test.js` to add tests for equivalence between `I have two apples` and `I have 2 apples`, and for tokenizing digit sequences like `1 2 3 4 5`.

### Testing
- Ran the unit test suite with `node --test app.test.js`, which executed 5 tests and all tests passed (5 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a489e01f083338c4fab1710161100)