### PR TITLE
Normalize time tokens before punctuation stripping

### DIFF
--- a/app.js
+++ b/app.js
@@ -2003,6 +2003,44 @@ const NUMBER_WORDS_BY_LANG = {
 };
 
 const DIGIT_TOKEN_PATTERN = /^\d+$/;
+const TIME_TOKEN_PATTERN = /\b\d{1,2}:\d{2}\b/g;
+const TIME_TOKEN_EXACT_PATTERN = /^\d{1,2}:\d{2}$/;
+
+function getHourWord(hourToken, langCode) {
+  const normalizedLang = (langCode || state.targetLang || 'en').split('-')[0];
+  const hourNum = Number.parseInt(hourToken, 10);
+  if (!Number.isFinite(hourNum)) return '';
+  if (normalizedLang === 'fr' && hourNum === 1) return 'une';
+  return digitToNumberWord(hourToken, normalizedLang);
+}
+
+function timeTokenToWords(token, langCode) {
+  if (!TIME_TOKEN_EXACT_PATTERN.test(token)) return '';
+  const [hours, minutes] = token.split(':');
+  if (minutes !== '00') return '';
+  const normalizedLang = (langCode || state.targetLang || 'en').split('-')[0];
+  const hourWord = getHourWord(hours, normalizedLang);
+  if (!hourWord) return '';
+
+  switch (normalizedLang) {
+    case 'en':
+      return `${hourWord} o'clock`;
+    case 'fr': {
+      const hourNum = Number.parseInt(hours, 10);
+      const noun = hourNum === 1 ? 'heure' : 'heures';
+      return `${hourWord} ${noun}`;
+    }
+    default:
+      return '';
+  }
+}
+
+function normalizeTimeTokens(text, langCode) {
+  return (text || '').replace(TIME_TOKEN_PATTERN, (match) => {
+    const replacement = timeTokenToWords(match, langCode);
+    return replacement || match;
+  });
+}
 
 function digitToNumberWord(token, langCode) {
   const normalizedLang = (langCode || state.targetLang || 'en').split('-')[0];
@@ -2029,7 +2067,8 @@ function normalizeToken(rawToken, langCode) {
 }
 
 function tokenizeText(t, langCode) {
-  return normalizeWord(t)
+  const timeNormalized = normalizeTimeTokens(t, langCode);
+  return normalizeWord(timeNormalized)
     .split(/\s+/)
     .map((token) => normalizeToken(token, langCode))
     .filter(Boolean);

--- a/app.test.js
+++ b/app.test.js
@@ -66,3 +66,17 @@ test('tokenizes French digit sequences into number words', () => {
     'cinq',
   ]);
 });
+
+test('normalizes time tokens to match o\'clock phrase in English', () => {
+  const timeTokens = tokenizeText('1:00', 'en');
+  const wordTokens = tokenizeText("one o'clock", 'en');
+
+  assert.deepStrictEqual(timeTokens, wordTokens);
+});
+
+test('normalizes time tokens to match hour phrases in French', () => {
+  const timeTokens = tokenizeText('1:00', 'fr');
+  const wordTokens = tokenizeText('une heure', 'fr');
+
+  assert.deepStrictEqual(timeTokens, wordTokens);
+});


### PR DESCRIPTION
### Motivation
- Tokenization should preserve language-appropriate spoken forms for time expressions so numeric times like `1:00` match their spelled-out equivalents during comparison. 
- The existing `normalizeWord` removed punctuation before any time-specific conversion, preventing `HH:MM` normalization. 
- Provide consistent behavior across supported languages (at least English and French) so `1:00` maps to the same tokens as `one o'clock` / `une heure`.

### Description
- Added time token recognition and conversion helpers in `app.js`: `TIME_TOKEN_PATTERN`, `TIME_TOKEN_EXACT_PATTERN`, `getHourWord`, `timeTokenToWords`, and `normalizeTimeTokens`. 
- Updated `tokenizeText` to run `normalizeTimeTokens(t, langCode)` before calling `normalizeWord`, ensuring time tokens are converted prior to punctuation-stripping. 
- Implemented language-aware conversions for `:00` times for `en` (e.g., `1:00 -> "one o'clock"`) and `fr` (e.g., `1:00 -> "une heure"`), reusing `digitToNumberWord` where appropriate. 
- Added unit tests in `app.test.js` to assert that `tokenizeText('1:00', 'en')` equals `tokenizeText("one o'clock", 'en')` and that `tokenizeText('1:00', 'fr')` equals `tokenizeText('une heure', 'fr')`.

### Testing
- Ran the test suite with `node --test`, and all tests passed (9 passed, 0 failed). 
- New tests cover English and French hour normalization and validated alongside existing number-tokenization tests. 
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6801547c8333a02373455edd88bb)