### PR TITLE
Treat Catalan `u` and `un` as equivalent tokens

### DIFF
--- a/app.js
+++ b/app.js
@@ -2166,6 +2166,8 @@ function levenshtein(a, b) {
 const EQUIV_GROUPS = {
   em: ['em', 'amb', 'en'],
   amb: ['em', 'amb', 'en'],
+  u: ['u', 'un'],
+  un: ['u', 'un'],
 };
 
 const APPROX_RULES_BY_LANG = {


### PR DESCRIPTION
### Motivation
- Align Catalan article handling so `u` and `un` are treated interchangeably during token comparison, preventing mismatches (e.g. between spoken and target text) when digit/article normalization differs.

### Description
- Add a small equivalence group in `EQUIV_GROUPS` mapping `u` <-> `un` so `similarityScore` will recognize them as equivalent and return the high equivalence score for those tokens.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7d0f198c83339da09ff5fba06c9e)