### PR TITLE
Only mark first incorrect token as 'wrong' on final results

### DIFF
--- a/app.js
+++ b/app.js
@@ -2337,15 +2337,17 @@ function updateLiveFeedback(transcript, { isFinalResult = false } = {}) {
     }
   }
 
-  let firstNotCorrect = -1;
-  for (let i = 0; i < n; i++) {
-    if (wordStatus[i] !== 'correct') {
-      firstNotCorrect = i;
-      break;
+  if (isFinalResult) {
+    let firstNotCorrect = -1;
+    for (let i = 0; i < n; i++) {
+      if (wordStatus[i] !== 'correct') {
+        firstNotCorrect = i;
+        break;
+      }
     }
-  }
-  if (firstNotCorrect !== -1) {
-    wordStatus[firstNotCorrect] = 'wrong';
+    if (firstNotCorrect !== -1) {
+      wordStatus[firstNotCorrect] = 'wrong';
+    }
   }
 
   for (let i = 0; i < n; i++) {


### PR DESCRIPTION
### Motivation
- Prevent brief green→red flicker in live feedback by avoiding marking words as `'wrong'` during interim updates and keeping live updates limited to `'correct'`/`'pending'`.

### Description
- Wrap the logic that finds the first non-`'correct'` token and sets it to `'wrong'` inside an `if (isFinalResult) { ... }` block in `updateLiveFeedback` in `app.js`, so the `'wrong'` status is only applied for final results.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bbe5d53448333bb30e2258bfe5115)