### PR TITLE
Lock correct prefix in live feedback updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -2325,21 +2325,34 @@ function updateLiveFeedback(transcript, { isFinalResult = false } = {}) {
 
   lastTranscript = filteredTranscript;
 
-  const matches = findMatchesForTargetTokens(targetTokens, filteredTokens);
   const prevStatus = [...wordStatus];
   const n = targetTokens.length;
+  let lockedPrefix = 0;
+
+  while (lockedPrefix < prevStatus.length && prevStatus[lockedPrefix] === 'correct') {
+    lockedPrefix += 1;
+  }
 
   wordStatus = targetTokens.map(() => 'pending');
 
-  for (let i = 0; i < n; i++) {
+  for (let i = 0; i < lockedPrefix; i++) {
+    wordStatus[i] = 'correct';
+  }
+
+  const matches = findMatchesForTargetTokens(
+    targetTokens.slice(lockedPrefix),
+    filteredTokens.slice(lockedPrefix)
+  );
+
+  for (let i = 0; i < matches.length; i++) {
     if (matches[i]) {
-      wordStatus[i] = 'correct';
+      wordStatus[i + lockedPrefix] = 'correct';
     }
   }
 
   if (isFinalResult) {
     let firstNotCorrect = -1;
-    for (let i = 0; i < n; i++) {
+    for (let i = lockedPrefix; i < n; i++) {
       if (wordStatus[i] !== 'correct') {
         firstNotCorrect = i;
         break;
@@ -2354,7 +2367,7 @@ function updateLiveFeedback(transcript, { isFinalResult = false } = {}) {
     const wasWrong = prevStatus[i] === 'wrong';
     const isNowCorrect = wordStatus[i] === 'correct';
     if (wasWrong && isNowCorrect) {
-      for (let k = i + 1; k < n; k++) {
+      for (let k = Math.max(i + 1, lockedPrefix); k < n; k++) {
         if (wordStatus[k] === 'correct') {
           wordStatus[k] = 'pending';
         }


### PR DESCRIPTION
### Motivation
- Ensure that once a token is marked `correct` it remains locked as `correct` in subsequent live-feedback updates to avoid regressions for earlier words.
- Avoid recomputing matches for indices already validated as correct so live feedback is stable while still allowing later words to update.
- Preserve existing behavior that later words can be reset to `pending` if an earlier wrong word is fixed, but never touch the locked prefix.

### Description
- In `updateLiveFeedback` compute a `lockedPrefix` by scanning `prevStatus` for leading `correct` entries and keep that prefix locked as `correct` in `wordStatus`.
- Only run `findMatchesForTargetTokens` on `targetTokens.slice(lockedPrefix)` and `filteredTokens.slice(lockedPrefix)` and map matches back with an offset of `lockedPrefix`.
- When computing the first not-correct word on final results, start the search at `lockedPrefix` so earlier locked indices are not changed.
- When applying the logic that resets later `correct` words to `pending` after a previously-`wrong` word becomes correct, restrict the reset loop to start at `Math.max(i + 1, lockedPrefix)` so the locked prefix is never modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc015c5048333ace41026e5744fa9)