### PR TITLE
Add CEFR approximation slider setting

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,16 @@ let availableLessons = [];
 const CUSTOM_LESSON_ID = 'custom';
 const VOICE_STORAGE_KEY = 'speechtoipa-voices';
 const DEFAULT_TTS_BASE_URL = 'https://translate.googleapis.com';
+const DEFAULT_APPROX_THRESHOLD = 0.65;
+const CEFR_LEVELS = [
+  { label: 'A1', value: 50 },
+  { label: 'A2', value: 60 },
+  { label: 'B1', value: 70 },
+  { label: 'B2', value: 80 },
+  { label: 'C1', value: 90 },
+  { label: 'C2', value: 100 },
+];
+const DEFAULT_CEFR_INDEX = 2;
 
 const MASTER_CSV_URLS = {
   ca: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQl1GNJGHAilkpQn3KiB0HnrUGEXSQp_dwo6A548izQXL-iAtAIHB2g3_o6VYAOv6UFuUOcISzJQO61/pub?gid=1216373156&single=true&output=csv',
@@ -149,6 +159,7 @@ const state = {
   pendingAutoAdvance: false,
   shouldAutoRestartRecognition: false,
   ttsLoading: false,
+  approxLevelIndex: DEFAULT_CEFR_INDEX,
 };
 
 const els = {};
@@ -442,6 +453,8 @@ function cacheElements() {
   els.voiceNote = document.getElementById('voice-note');
   els.baseSelect = document.getElementById('base-lang');
   els.lessonSelect = document.getElementById('lesson-select');
+  els.approxSlider = document.getElementById('approx-slider');
+  els.approxLabel = document.getElementById('approx-label');
   els.sentence = document.getElementById('sentence');
   els.play = document.getElementById('play-btn');
   els.slow = document.getElementById('slow-btn');
@@ -491,6 +504,64 @@ function populateSelect(select, options, selected) {
     if (opt.code === selected) option.selected = true;
     select.appendChild(option);
   });
+}
+
+function clampCefrIndex(index) {
+  const max = CEFR_LEVELS.length - 1;
+  if (!Number.isFinite(index)) return DEFAULT_CEFR_INDEX;
+  return Math.min(max, Math.max(0, Math.round(index)));
+}
+
+function getCefrLevel(index) {
+  return CEFR_LEVELS[clampCefrIndex(index)] || CEFR_LEVELS[DEFAULT_CEFR_INDEX];
+}
+
+function getApproxThresholdFromIndex(index) {
+  const level = getCefrLevel(index);
+  return level.value / 100;
+}
+
+function updateApproxLabel() {
+  if (!els.approxLabel) return;
+  const level = getCefrLevel(state.approxLevelIndex);
+  els.approxLabel.textContent = `Approximation tolerance: ${level.label} (${level.value}%)`;
+}
+
+function readStoredProgressData() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  let data = { progress: {} };
+  try {
+    data = raw ? JSON.parse(raw) : { progress: {} };
+  } catch {
+    data = { progress: {} };
+  }
+  if (!data.progress) data.progress = {};
+  return data;
+}
+
+function writeStoredProgressData(data) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+function persistApproxSettings() {
+  try {
+    const data = readStoredProgressData();
+    data.approxLevelIndex = state.approxLevelIndex;
+    writeStoredProgressData(data);
+  } catch (err) {
+    console.warn('Failed to save approximation settings', err);
+  }
+}
+
+function setApproxLevel(index, { persist = true } = {}) {
+  state.approxLevelIndex = clampCefrIndex(index);
+  if (els.approxSlider) {
+    els.approxSlider.value = String(state.approxLevelIndex);
+  }
+  updateApproxLabel();
+  if (persist) {
+    persistApproxSettings();
+  }
 }
 
 function getStoredVoices() {
@@ -692,6 +763,11 @@ function attachEventListeners() {
     handleLessonSelection(els.lessonSelect.value);
   });
 
+  els.approxSlider?.addEventListener('input', (event) => {
+    const nextIndex = Number(event.target.value);
+    setApproxLevel(nextIndex);
+  });
+
   els.play.addEventListener('click', () => speakCurrent(1));
   els.slow.addEventListener('click', () => speakCurrent(0.7));
   els.next.addEventListener('click', () => goToNext());
@@ -822,9 +898,16 @@ function closeCustomModal(resetSelection = false) {
 
 function hydrateFromStorage() {
   const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) return;
+  let saved = null;
   try {
-    const saved = normalizeLegacyCodes(JSON.parse(raw));
+    if (raw) {
+      saved = normalizeLegacyCodes(JSON.parse(raw));
+    }
+  } catch (err) {
+    console.error('Failed to parse saved progress', err);
+  }
+
+  if (saved) {
     if (saved.targetLang) state.targetLang = saved.targetLang;
     if (saved.baseLang) state.baseLang = saved.baseLang;
     if (saved.lessonId && saved.lessonId !== CUSTOM_LESSON_ID) {
@@ -836,9 +919,14 @@ function hydrateFromStorage() {
     populateSelect(els.targetSelect, TARGET_LANGS, state.targetLang);
     populateSelect(els.baseSelect, BASE_LANGS, state.baseLang);
     populateLessonSelect();
-  } catch (err) {
-    console.error('Failed to parse saved progress', err);
   }
+
+  if (saved && Number.isFinite(saved.approxLevelIndex)) {
+    state.approxLevelIndex = clampCefrIndex(saved.approxLevelIndex);
+  } else {
+    state.approxLevelIndex = DEFAULT_CEFR_INDEX;
+  }
+  setApproxLevel(state.approxLevelIndex, { persist: false });
 
   voiceSelections = getStoredVoices();
   populateVoiceSelect();
@@ -864,16 +952,11 @@ function normalizeLegacyCodes(saved) {
 
 function saveProgress(bestScore) {
   if (state.mode === 'custom') return;
-  const raw = localStorage.getItem(STORAGE_KEY);
-  let data = { progress: {} };
-  try {
-    data = raw ? JSON.parse(raw) : { progress: {} };
-  } catch {
-    data = { progress: {} };
-  }
+  const data = readStoredProgressData();
   data.targetLang = state.targetLang;
   data.baseLang = state.baseLang;
   data.lessonId = state.lessonId;
+  data.approxLevelIndex = state.approxLevelIndex;
   data.progress = data.progress || {};
   data.progress[state.lessonId] = data.progress[state.lessonId] || { currentIndex: 0, scores: {} };
   data.progress[state.lessonId].currentIndex = state.currentIndex;
@@ -882,7 +965,7 @@ function saveProgress(bestScore) {
     if (!data.progress[state.lessonId].scores) data.progress[state.lessonId].scores = {};
     data.progress[state.lessonId].scores[currentSentence().id] = Math.max(previous, bestScore);
   }
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  writeStoredProgressData(data);
 }
 
 function updateLessonId() {
@@ -2172,15 +2255,17 @@ const EQUIV_GROUPS = {
 
 const APPROX_RULES_BY_LANG = {
   default: {
-    coverageThreshold: 0.65,
+    coverageThreshold: DEFAULT_APPROX_THRESHOLD,
   },
 };
 
 function getApproxRules(langCode) {
-  if (langCode && APPROX_RULES_BY_LANG[langCode]) {
-    return APPROX_RULES_BY_LANG[langCode];
-  }
-  return APPROX_RULES_BY_LANG.default || {};
+  const baseRules =
+    langCode && APPROX_RULES_BY_LANG[langCode]
+      ? APPROX_RULES_BY_LANG[langCode]
+      : APPROX_RULES_BY_LANG.default || {};
+  const coverageThreshold = getApproxThresholdFromIndex(state.approxLevelIndex);
+  return { ...baseRules, coverageThreshold };
 }
 
 function orderedCharacterCoverage(target, candidate) {

--- a/index.html
+++ b/index.html
@@ -32,6 +32,14 @@
       <label for="lesson-select">Lesson:</label>
       <select id="lesson-select"></select>
     </div>
+    <div class="field">
+      <label for="approx-slider">Approximation tolerance:</label>
+      <input id="approx-slider" type="range" min="0" max="5" step="1" value="2" />
+      <div class="range-meta">
+        <p id="approx-label" class="small">Approximation tolerance: B1 (70%)</p>
+        <p class="small">Lower = more lenient, higher = stricter.</p>
+      </div>
+    </div>
   </section>
 
   <main id="app" class="card" aria-live="polite">

--- a/styles.css
+++ b/styles.css
@@ -70,6 +70,19 @@ select, button, textarea {
   font-size: 1rem;
 }
 
+input[type="range"] {
+  width: 100%;
+  margin: 0.3rem 0 0;
+  accent-color: var(--accent);
+}
+
+.range-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-top: 0.4rem;
+}
+
 button {
   cursor: pointer;
   transition: transform 0.1s ease, box-shadow 0.1s ease;


### PR DESCRIPTION
### Motivation
- Provide a user-configurable approximation tolerance (CEFR A1→C2) to replace the hard-coded `0.65` threshold used for fuzzy token matching. 
- Surface the setting in the existing settings UI so users can control leniency/strictness of matching and persist their choice.

### Description
- UI: add a new settings field in `index.html` with a labeled slider `#approx-slider`, a display label `#approx-label`, and helper text (`Lower = more lenient, higher = stricter`).
- Styles: add styles in `styles.css` for `input[type="range"]` and `.range-meta` so the slider matches existing settings layout.
- App logic: introduce `CEFR_LEVELS` mapping (`A1=50, A2=60, B1=70, B2=80, C1=90, C2=100`) and `DEFAULT_CEFR_INDEX`, plus `DEFAULT_APPROX_THRESHOLD` constant in `app.js`.
- State & DOM: add `state.approxLevelIndex` and cache DOM refs `els.approxSlider` and `els.approxLabel` in `cacheElements`.
- Helpers & persistence: add `clampCefrIndex`, `getCefrLevel`, `getApproxThresholdFromIndex`, `updateApproxLabel`, storage helpers `readStoredProgressData` / `writeStoredProgressData`, `persistApproxSettings`, and `setApproxLevel` to convert slider index ↔ threshold and persist the selection inside the existing `STORAGE_KEY` payload.
- Hydration & events: hydrate `approxLevelIndex` from storage in `hydrateFromStorage()` (default → B1/B2 nearest step via `DEFAULT_CEFR_INDEX`), wire slider `input` events to `setApproxLevel`, and update the UI label when changed.
- Matching rules: update `getApproxRules` to compute `coverageThreshold` from the current CEFR index (via `getApproxThresholdFromIndex`) instead of using the hard-coded `0.65`, so `passesApproximationRule` now uses the user-defined threshold.

### Testing
- Created a live page screenshot using a Playwright script against a local HTTP server to visually verify the new slider UI; the screenshot run completed successfully and an artifact was produced.
- No automated unit tests were executed against the modified code in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981aee42de483338beec0dfd101c80f)