### PR TITLE
Remove CEFR labels from approximation tolerance and show percentage only

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,14 +22,7 @@ const CUSTOM_LESSON_ID = 'custom';
 const VOICE_STORAGE_KEY = 'speechtoipa-voices';
 const DEFAULT_TTS_BASE_URL = 'https://translate.googleapis.com';
 const DEFAULT_APPROX_THRESHOLD = 0.65;
-const CEFR_LEVELS = [
-  { label: 'A1', value: 50 },
-  { label: 'A2', value: 60 },
-  { label: 'B1', value: 70 },
-  { label: 'B2', value: 80 },
-  { label: 'C1', value: 90 },
-  { label: 'C2', value: 100 },
-];
+const CEFR_LEVELS = [50, 60, 70, 80, 90, 100];
 const DEFAULT_CEFR_INDEX = 2;
 
 const MASTER_CSV_URLS = {
@@ -512,19 +505,15 @@ function clampCefrIndex(index) {
   return Math.min(max, Math.max(0, Math.round(index)));
 }
 
-function getCefrLevel(index) {
-  return CEFR_LEVELS[clampCefrIndex(index)] || CEFR_LEVELS[DEFAULT_CEFR_INDEX];
-}
-
 function getApproxThresholdFromIndex(index) {
-  const level = getCefrLevel(index);
-  return level.value / 100;
+  const level = CEFR_LEVELS[clampCefrIndex(index)] || CEFR_LEVELS[DEFAULT_CEFR_INDEX];
+  return level / 100;
 }
 
 function updateApproxLabel() {
   if (!els.approxLabel) return;
-  const level = getCefrLevel(state.approxLevelIndex);
-  els.approxLabel.textContent = `Approximation tolerance: ${level.label} (${level.value}%)`;
+  const level = CEFR_LEVELS[clampCefrIndex(state.approxLevelIndex)] || CEFR_LEVELS[DEFAULT_CEFR_INDEX];
+  els.approxLabel.textContent = `Approximation tolerance: for Accuracy ${level}%:`;
 }
 
 function readStoredProgressData() {

--- a/index.html
+++ b/index.html
@@ -36,8 +36,7 @@
       <label for="approx-slider">Approximation tolerance:</label>
       <input id="approx-slider" type="range" min="0" max="5" step="1" value="2" />
       <div class="range-meta">
-        <p id="approx-label" class="small">Approximation tolerance: B1 (70%)</p>
-        <p class="small">Lower = more lenient, higher = stricter.</p>
+        <p id="approx-label" class="small">Approximation tolerance: for Accuracy 70%:</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
### Motivation
- The UI should display approximation tolerance as a plain percentage for accuracy instead of CEFR labels (A1–C2) to simplify wording.
- The helper text below the slider should be reduced to a single concise line and the secondary hint removed.

### Description
- Replaced the CEFR level objects with a numeric `CEFR_LEVELS` array of percentage values in `app.js` and removed the `getCefrLevel` indirection.
- Updated `getApproxThresholdFromIndex` to read numeric levels and return a normalized threshold, and changed `updateApproxLabel` to render only the percentage text (`Approximation tolerance: for Accuracy XX%:`) in `app.js`.
- Modified `index.html` to change the default helper text to `Approximation tolerance: for Accuracy 70%:` and removed the secondary hint line.

### Testing
- Started a local static server with `python -m http.server 8000` to load the app, which started successfully.
- Attempted to capture a UI screenshot with Playwright, but the headless Chromium process crashed (SIGSEGV) so the visual check failed.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981beb61f4c8333b2a388ec1fbac1ee)