### PR TITLE
Simplify accuracy slider label

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ const VOICE_STORAGE_KEY = 'speechtoipa-voices';
 const DEFAULT_TTS_BASE_URL = 'https://translate.googleapis.com';
 const DEFAULT_APPROX_THRESHOLD = 0.65;
 const CEFR_LEVELS = [50, 60, 70, 80, 90, 100];
-const DEFAULT_CEFR_INDEX = 2;
+const DEFAULT_CEFR_INDEX = 0;
 
 const MASTER_CSV_URLS = {
   ca: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQl1GNJGHAilkpQn3KiB0HnrUGEXSQp_dwo6A548izQXL-iAtAIHB2g3_o6VYAOv6UFuUOcISzJQO61/pub?gid=1216373156&single=true&output=csv',
@@ -513,7 +513,7 @@ function getApproxThresholdFromIndex(index) {
 function updateApproxLabel() {
   if (!els.approxLabel) return;
   const level = CEFR_LEVELS[clampCefrIndex(state.approxLevelIndex)] || CEFR_LEVELS[DEFAULT_CEFR_INDEX];
-  els.approxLabel.textContent = `Approximation tolerance: for Accuracy ${level}%:`;
+  els.approxLabel.textContent = `Accuracy ${level}%`;
 }
 
 function readStoredProgressData() {

--- a/index.html
+++ b/index.html
@@ -33,11 +33,11 @@
       <select id="lesson-select"></select>
     </div>
     <div class="field">
-      <label for="approx-slider">Approximation tolerance:</label>
-      <input id="approx-slider" type="range" min="0" max="5" step="1" value="2" />
+      <label for="approx-slider" class="sr-only">Accuracy</label>
       <div class="range-meta">
-        <p id="approx-label" class="small">Approximation tolerance: for Accuracy 70%:</p>
+        <p id="approx-label" class="small">Accuracy 50%</p>
       </div>
+      <input id="approx-slider" type="range" min="0" max="5" step="1" value="0" />
     </div>
   </section>
 

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,18 @@ label {
   margin-bottom: 0.35rem;
 }
 
+.sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
+}
+
 select, button, textarea {
   width: 100%;
   padding: 0.65rem 0.75rem;


### PR DESCRIPTION
### Motivation
- Simplify the slider UI by exposing a concise accuracy label above the slider, make the visible default show 50%, and keep the hidden form label accessible to screen readers.

### Description
- Hide the redundant visible label in `index.html` using a `sr-only` utility, render a short `Accuracy 50%` label above the slider and set the slider `value` to map to that setting, update `app.js` to use `DEFAULT_CEFR_INDEX = 0` and set `updateApproxLabel` to `Accuracy ${level}%`, and add the `.sr-only` rule to `styles.css`.

### Testing
- Performed an automated UI check by starting a local server with `python -m http.server 8000` and running a Playwright script that loaded the page and captured `artifacts/accuracy-slider.png`, confirming the label shows `Accuracy 50%` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c9942204833389144a91968f38c3)