### PR TITLE
Refine settings label styling and simplify voice note

### DIFF
--- a/app.js
+++ b/app.js
@@ -624,7 +624,7 @@ function updateVoiceNote() {
     els.voiceNote.textContent = 'Auto picks the best match for each language.';
   } else {
     const [, name] = selection.split('|');
-    els.voiceNote.textContent = `Using voice: ${name}`;
+    els.voiceNote.textContent = name;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -16,26 +16,26 @@
 
   <section class="settings" aria-label="Language selection">
     <div class="field">
-      <label for="target-lang">Target language (L2):</label>
+      <label class="field-title" for="target-lang">Target language (L2):</label>
       <select id="target-lang"></select>
     </div>
     <div class="field">
-      <label for="voice-select">Voice for target language:</label>
+      <label class="field-title" for="voice-select">Voice for target language:</label>
       <select id="voice-select"></select>
       <p id="voice-note" class="small"></p>
     </div>
     <div class="field">
-      <label for="base-lang">Base language (L1):</label>
+      <label class="field-title" for="base-lang">Base language (L1):</label>
       <select id="base-lang"></select>
     </div>
     <div class="field">
-      <label for="lesson-select">Lesson:</label>
+      <label class="field-title" for="lesson-select">Lesson:</label>
       <select id="lesson-select"></select>
     </div>
     <div class="field">
       <label for="approx-slider" class="sr-only">Accuracy</label>
       <div class="range-meta">
-        <p id="approx-label" class="small">Accuracy 50%</p>
+        <p id="approx-label" class="field-title">Accuracy 50%</p>
       </div>
       <input id="approx-slider" type="range" min="0" max="5" step="1" value="0" />
     </div>

--- a/styles.css
+++ b/styles.css
@@ -45,6 +45,7 @@ h1 {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1rem;
   margin-bottom: 1rem;
+  align-items: start;
 }
 
 .field {
@@ -52,12 +53,17 @@ h1 {
   border: 1px solid var(--border);
   padding: 0.75rem;
   border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
 }
 
+.field-title,
 label {
   display: block;
   font-weight: 600;
-  margin-bottom: 0.35rem;
+  margin: 0;
+  font-size: 0.95rem;
 }
 
 .sr-only {
@@ -92,7 +98,6 @@ input[type="range"] {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
-  margin-top: 0.4rem;
 }
 
 button {


### PR DESCRIPTION
### Motivation
- Improve vertical alignment and visual consistency of the settings field titles in the app UI. 
- Simplify the voice selection note so it shows only the voice name without the extra "Using voice:" prefix.

### Description
- Added a `field-title` class to settings labels in `index.html` and applied it to the accuracy label. 
- Updated `styles.css` to vertically align settings by adding `align-items: start` to `.settings`, make `.field` a vertical flex container, and standardize label spacing and font size via `.field-title, label`.
- Removed the leading text from the voice note in `app.js` so `updateVoiceNote()` sets `els.voiceNote.textContent` to just the voice name when a specific voice is selected. 
- Changes touch `index.html`, `styles.css`, and `app.js` to keep layout and text consistent.

### Testing
- Launched a local dev server with `python -m http.server 8000` and captured a visual verification screenshot using a Playwright script, which completed successfully and produced `artifacts/settings-alignment.png`.
- No automated unit tests were run or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981cd1ad3a483339bfa6f7474d305ad)