### PR TITLE
Remove voice helper text and align accuracy label styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -443,7 +443,6 @@ if (typeof document !== 'undefined') {
 function cacheElements() {
   els.targetSelect = document.getElementById('target-lang');
   els.voiceSelect = document.getElementById('voice-select');
-  els.voiceNote = document.getElementById('voice-note');
   els.baseSelect = document.getElementById('base-lang');
   els.lessonSelect = document.getElementById('lesson-select');
   els.approxSlider = document.getElementById('approx-slider');
@@ -609,23 +608,6 @@ function populateVoiceSelect() {
 
   const stored = voiceSelections[state.targetLang] || AUTO_VOICE_VALUE;
   els.voiceSelect.value = stored;
-  updateVoiceNote();
-}
-
-function updateVoiceNote() {
-  if (!els.voiceNote) return;
-  if (!normalizedVoices.length) {
-    els.voiceNote.textContent = 'Voices will appear after your browser loads them.';
-    return;
-  }
-
-  const selection = voiceSelections[state.targetLang] || AUTO_VOICE_VALUE;
-  if (selection === AUTO_VOICE_VALUE) {
-    els.voiceNote.textContent = 'Auto picks the best match for each language.';
-  } else {
-    const [, name] = selection.split('|');
-    els.voiceNote.textContent = name;
-  }
 }
 
 function getLessonsForLang(lang) {
@@ -837,7 +819,6 @@ function attachEventListeners() {
     voiceSelections[state.targetLang] = els.voiceSelect.value;
     playbackQueue.resetWarmup(getLangCode(state.targetLang));
     persistVoices();
-    updateVoiceNote();
     updatePlaybackWarnings();
   });
 }
@@ -1496,7 +1477,6 @@ function createPlaybackQueue() {
 
     const promise = (async () => {
       isWarming = true;
-      setStatus('Preparing audio…');
       try {
         await waitForVoicesReady();
         return getVoiceForLang(langCode);

--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
     <div class="field">
       <label class="field-title" for="voice-select">Voice for target language:</label>
       <select id="voice-select"></select>
-      <p id="voice-note" class="small"></p>
     </div>
     <div class="field">
       <label class="field-title" for="base-lang">Base language (L1):</label>
@@ -33,10 +32,7 @@
       <select id="lesson-select"></select>
     </div>
     <div class="field">
-      <label for="approx-slider" class="sr-only">Accuracy</label>
-      <div class="range-meta">
-        <p id="approx-label" class="field-title">Accuracy 50%</p>
-      </div>
+      <label id="approx-label" class="field-title" for="approx-slider">Accuracy 50%</label>
       <input id="approx-slider" type="range" min="0" max="5" step="1" value="0" />
     </div>
   </section>

--- a/styles.css
+++ b/styles.css
@@ -94,12 +94,6 @@ input[type="range"] {
   accent-color: var(--accent);
 }
 
-.range-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-}
-
 button {
   cursor: pointer;
   transition: transform 0.1s ease, box-shadow 0.1s ease;


### PR DESCRIPTION
### Motivation
- Clean up the settings UI by removing an unnecessary helper line under the voice selector and make the accuracy control label visually consistent with other selector titles.
- Avoid showing a transient status message while warming TTS voices to reduce noisy UI feedback.

### Description
- Removed the `voice-note` element from `index.html` and removed all related wiring and the `updateVoiceNote` logic from `app.js` so the voice selector no longer shows helper text.
- Converted the accuracy label structure in `index.html` to use a single `label` with class `field-title` (`id="approx-label"`) so it matches other selector titles instead of using a hidden label + `.range-meta` wrapper.
- Deleted the `.range-meta` CSS block from `styles.css` to reflect the simplified DOM structure.
- Stopped setting the status message `Preparing audio…` during voice warmup by removing the `setStatus('Preparing audio…')` call in the voice warmup flow in `app.js`.

### Testing
- Started a static server with `python -m http.server` and used a Playwright script to load `index.html` and capture a screenshot (`artifacts/voice-accuracy-update.png`), and the page loaded and the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d367a5dc8333aea6225d0ee38abf)