### PR TITLE
Update title/remove header and add TTS URL fallback for failed fetch playback

### DIFF
--- a/app.js
+++ b/app.js
@@ -335,6 +335,29 @@ async function playTtsBlob(blob, rate = 1.0) {
   await playbackFinished;
 }
 
+async function playTtsUrl(url, rate = 1.0) {
+  if (!url) return false;
+  const audio = new Audio();
+  audio.src = url;
+  audio.preload = 'auto';
+  audio.playbackRate = rate;
+
+  const playbackFinished = new Promise((resolve) => {
+    audio.onended = () => resolve(true);
+    audio.onerror = () => resolve(false);
+  });
+
+  try {
+    await audio.play();
+    setStatus('Playing audio from TTS service.');
+  } catch (err) {
+    console.error('Failed to play TTS service audio URL', err);
+    return false;
+  }
+
+  return playbackFinished;
+}
+
 function parseCsvToObjects(text) {
   const rows = [];
   let current = '';
@@ -1540,12 +1563,18 @@ function createPlaybackQueue() {
   }
 
   async function speakWithService(item) {
+    const baseUrl = getTtsBaseUrl();
+    const ttsUrl = buildTtsRequestUrl(baseUrl, item.text, item.langCode);
     try {
       const blob = await fetchTtsAudio(item.text, item.langCode);
       await playTtsBlob(blob, item.rate);
       return true;
     } catch (err) {
       console.error('TTS service request failed', err);
+      const playedViaUrl = await playTtsUrl(ttsUrl, item.rate);
+      if (playedViaUrl) {
+        return true;
+      }
       setStatus('TTS service unavailable. Check configuration and try again.');
       return false;
     }

--- a/index.html
+++ b/index.html
@@ -5,15 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Optional: override the TTS fallback service base URL (defaults to translate.googleapis.com) -->
   <!-- <meta name="tts-base-url" content="https://your-tts-service.example.com"> -->
-  <title>Read • Listen • Speak</title>
+  <title>Speech to IPA</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header>
-    <h1>Read • Listen • Speak</h1>
-    <p class="tagline">Practice reading, listening and pronunciation step by step.</p>
-  </header>
-
   <section class="settings" aria-label="Language selection">
     <div class="field">
       <label class="field-title" for="target-lang">Target language (L2):</label>


### PR DESCRIPTION
### Motivation
- Remove the visible "Read • Listen • Speak" header/tagline and update the document title to avoid the requested text remaining on the page. 
- Improve TTS playback reliability on devices (notably some Android setups) where fetching and playing TTS audio blobs can fail by providing a URL-based playback fallback.

### Description
- Update `index.html` to set `<title>Speech to IPA</title>` and remove the header/tagline block. 
- Add a new `playTtsUrl(url, rate)` function in `app.js` that plays remote audio via `Audio.src`. 
- Modify `speakWithService` to construct the TTS URL with `buildTtsRequestUrl` and attempt `playTtsUrl` if `fetchTtsAudio` fails, falling back to the URL-based playback before reporting the service as unavailable. 
- Keep existing blob-fetch-and-cache logic intact so the URL fallback is only used when fetch-based playback fails.

### Testing
- Launched a local HTTP server and ran a Playwright script that loaded `http://127.0.0.1:8000/` and captured a screenshot of the updated homepage, which completed successfully and produced `artifacts/speechtoipa-home.png`. 
- No unit tests or CI were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69827d706e708333907b0b1132408e47)