### PR TITLE
Improve mobile TTS playback reliability

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,6 +45,8 @@ const DARJA_TRANSCRIPTION_FALLBACK_HEADERS = [
 
 const NO_TTS_SUPPORT_MESSAGE =
   'No local text-to-speech voice found. Using fallback TTS service for playback.';
+const SILENT_AUDIO_DATA_URL =
+  'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA=';
 
 const TTS_CACHE_PREFIX = 'speechtoipa-tts:';
 const TTS_LOCAL_CACHE_CHAR_LIMIT = 180;
@@ -112,6 +114,31 @@ function isSpeechSynthesisSupported() {
   return Boolean(window.speechSynthesis) && 'SpeechSynthesisUtterance' in window;
 }
 
+function unlockAudioPlayback() {
+  if (!isMobileDevice() || audioUnlockState.ready || audioUnlockState.pending) return;
+  audioUnlockState.pending = true;
+  const audio = new Audio(SILENT_AUDIO_DATA_URL);
+  audio.preload = 'auto';
+  audio.volume = 0;
+
+  const handleSuccess = () => {
+    audioUnlockState.ready = true;
+    audioUnlockState.pending = false;
+  };
+
+  const handleFailure = (err) => {
+    console.warn('Unable to unlock audio playback', err);
+    audioUnlockState.pending = false;
+  };
+
+  const playPromise = audio.play();
+  if (playPromise && typeof playPromise.then === 'function') {
+    playPromise.then(handleSuccess).catch(handleFailure);
+  } else {
+    handleSuccess();
+  }
+}
+
 if (typeof window !== 'undefined' && window.speechSynthesis) {
   window.speechSynthesis.onvoiceschanged = () => {
     window.speechSynthesis.getVoices();
@@ -159,6 +186,7 @@ const els = {};
 let normalizedVoices = [];
 let voiceSelections = {};
 const readyVoiceKeys = new Set();
+const audioUnlockState = { ready: false, pending: false };
 
 function getVoiceKey(voice) {
   if (!voice) return '';
@@ -762,14 +790,21 @@ function attachEventListeners() {
     setApproxLevel(nextIndex);
   });
 
-  els.play.addEventListener('click', () => speakCurrent(1));
-  els.slow.addEventListener('click', () => speakCurrent(0.7));
+  els.play.addEventListener('click', () => {
+    unlockAudioPlayback();
+    speakCurrent(1);
+  });
+  els.slow.addEventListener('click', () => {
+    unlockAudioPlayback();
+    speakCurrent(0.7);
+  });
   els.next.addEventListener('click', () => goToNext());
   els.record.addEventListener('click', startRecording);
   els.stop.addEventListener('click', stopRecording);
 
   els.sentence.addEventListener('click', (e) => {
     if (e.target.classList.contains('word')) {
+      unlockAudioPlayback();
       speakWord(e.target.dataset.word);
       e.target.classList.toggle('active');
     }
@@ -1565,6 +1600,12 @@ function createPlaybackQueue() {
   async function speakWithService(item) {
     const baseUrl = getTtsBaseUrl();
     const ttsUrl = buildTtsRequestUrl(baseUrl, item.text, item.langCode);
+    if (isMobileDevice()) {
+      const playedViaUrl = await playTtsUrl(ttsUrl, item.rate);
+      if (playedViaUrl) {
+        return true;
+      }
+    }
     try {
       const blob = await fetchTtsAudio(item.text, item.langCode);
       await playTtsBlob(blob, item.rate);


### PR DESCRIPTION
### Motivation
- Mobile browsers (tablets/phones) often block audio playback unless primed by a user gesture, causing messages like `No local text-to-speech is available` and `TTS service unavailable` and preventing audio playback. 
- The goal is to make playback more reliable on Android/iOS by ensuring audio is unlocked on first user interaction and by avoiding blob-fetch playback failure modes on mobile.

### Description
- Add a silent audio data URL and an `audioUnlockState` to track unlock progress and a new `unlockAudioPlayback()` helper that plays a zero-length silent clip on first user gestures to prime mobile audio.
- Call `unlockAudioPlayback()` from the main playback entry points (play/slow buttons and word taps) so playback is prepared by the user gesture before attempting TTS playback.
- Update `speakWithService()` to attempt direct TTS URL playback via `playTtsUrl()` first on mobile devices before fetching and playing blobs, which reduces fetch/gesture/CORS failure cases.
- Minimal state added: `SILENT_AUDIO_DATA_URL` and `audioUnlockState` to coordinate the unlock flow.

### Testing
- No automated tests were executed for this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698286100a148333b9739666d6987c9e)