### PR TITLE
Simplify voice selector display

### DIFF
--- a/app.js
+++ b/app.js
@@ -486,7 +486,6 @@ if (typeof document !== 'undefined') {
 function cacheElements() {
   els.targetSelect = document.getElementById('target-lang');
   els.voiceSelect = document.getElementById('voice-select');
-  els.voiceNote = document.getElementById('voice-note');
   els.baseSelect = document.getElementById('base-lang');
   els.lessonSelect = document.getElementById('lesson-select');
   els.approxSlider = document.getElementById('approx-slider');
@@ -652,23 +651,6 @@ function populateVoiceSelect() {
 
   const stored = voiceSelections[state.targetLang] || AUTO_VOICE_VALUE;
   els.voiceSelect.value = stored;
-  updateVoiceNote();
-}
-
-function updateVoiceNote() {
-  if (!els.voiceNote) return;
-  if (!normalizedVoices.length) {
-    els.voiceNote.textContent = '';
-    return;
-  }
-
-  const selection = voiceSelections[state.targetLang] || AUTO_VOICE_VALUE;
-  if (selection === AUTO_VOICE_VALUE) {
-    els.voiceNote.textContent = '';
-  } else {
-    const [, name] = selection.split('|');
-    els.voiceNote.textContent = name;
-  }
 }
 
 function getLessonsForLang(lang) {
@@ -880,7 +862,6 @@ function attachEventListeners() {
     voiceSelections[state.targetLang] = els.voiceSelect.value;
     playbackQueue.resetWarmup(getLangCode(state.targetLang));
     persistVoices();
-    updateVoiceNote();
     updatePlaybackWarnings();
   });
 }

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <div class="field">
       <label class="field-title" for="voice-select">Voice for target language:</label>
       <select id="voice-select"></select>
-      <p id="voice-note" class="small"></p>
     </div>
     <div class="field">
       <label class="field-title" for="base-lang">Base language (L1):</label>


### PR DESCRIPTION
### Motivation
- Remove a redundant line under the voice selector so the settings UI shows only the label and the selection control.

### Description
- Removed the `#voice-note` paragraph from `index.html` so the voice selector contains just the label and `<select id="voice-select">`.
- Dropped the `els.voiceNote` lookup and the `updateVoiceNote` function and removed calls to it in `app.js` to clean up unused wiring.
- Changes are limited to `index.html` and `app.js` with no behavioral change to playback or voice selection logic.

### Testing
- Launched a local HTTP server with `python -m http.server 8000` and captured a UI screenshot via a Playwright script which completed and produced `artifacts/voice-selector.png` successfully.
- No unit tests were run against the codebase during this change since this is a presentational cleanup only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837efc20f88333a44052b08ba69593)