### PR TITLE
Set default TTS base URL to translate.googleapis.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Optional: override the TTS fallback service base URL (defaults to translate.googleapis.com) -->
-  <!-- <meta name="tts-base-url" content="https://your-tts-service.example.com"> -->
+  <meta name="tts-base-url" content="https://translate.googleapis.com" />
+  <!-- Optional: override the TTS fallback service base URL -->
+  <!-- <meta name="tts-base-url" content="https://your-tts-service.example.com" /> -->
   <title>Speech to IPA</title>
   <link rel="stylesheet" href="styles.css" />
 </head>


### PR DESCRIPTION
### Motivation
- Ensure the app reads a concrete TTS base URL before `app.js` loads so requests that build `/translate_tts` use Google Translate by default.

### Description
- Add `<meta name="tts-base-url" content="https://translate.googleapis.com" />` to `index.html` and update the inline comment for the optional override.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c8cc2e788333ad3af8cd17388c8f)