### PR TITLE
Handle Google Translate TTS CORS fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -298,34 +298,57 @@ async function fetchTtsAudio(text, langCode) {
   setStatus('Fetching audio from TTS service…');
   try {
     const url = buildTtsRequestUrl(baseUrl, text, langCode);
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`TTS service returned ${res.status}`);
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`TTS service returned ${res.status}`);
+      }
+      const blob = await res.blob();
+      await cacheTts(cacheKey, blob, text);
+      return blob;
+    } catch (err) {
+      if (isGoogleTranslateTts(baseUrl)) {
+        const audio = getPlaybackAudioElement();
+        if (audio) {
+          audio.src = url;
+          return { directUrl: url };
+        }
+      }
+      throw err;
     }
-    const blob = await res.blob();
-    await cacheTts(cacheKey, blob, text);
-    return blob;
   } finally {
     setTtsLoading(false);
   }
 }
 
-async function playTtsBlob(blob, rate = 1.0) {
-  if (!blob) return;
+async function playTtsBlob(source, rate = 1.0) {
+  if (!source) return;
   if (!state.audioUnlocked) {
     setStatus('Tap Play again to enable audio.');
     await unlockAudioPlayback();
     if (!state.audioUnlocked) return;
   }
-  const url = URL.createObjectURL(blob);
   const audio = getPlaybackAudioElement();
   if (!audio) return;
+  let url = '';
+  let shouldRevoke = false;
+  if (source instanceof Blob) {
+    url = URL.createObjectURL(source);
+    shouldRevoke = true;
+  } else if (typeof source === 'string') {
+    url = source;
+  } else if (source && source.directUrl) {
+    url = source.directUrl;
+  }
+  if (!url) return;
   audio.src = url;
   audio.playbackRate = rate;
 
   const playbackFinished = new Promise((resolve) => {
     const finish = () => {
-      URL.revokeObjectURL(url);
+      if (shouldRevoke) {
+        URL.revokeObjectURL(url);
+      }
       resolve();
     };
     audio.onended = finish;


### PR DESCRIPTION
### Motivation
- Avoid failing playback when `fetch()` to Google Translate TTS is blocked by CORS by providing a fallback that uses the audio element directly.
- Preserve existing caching and fetched-blob behavior when `fetch()` succeeds while still enabling client-only playback when needed.

### Description
- Update `fetchTtsAudio()` to attempt `fetch(url)` as before, and on fetch error detect Google Translate TTS and fall back to setting the playback `<audio>` element `src` to the TTS URL, returning a `{ directUrl }` object when that path is used.
- Change `playTtsBlob()` signature to `playTtsBlob(source, rate)` and accept a `Blob`, a string URL, or the `{ directUrl }` object and treat each appropriately.
- Only call `URL.revokeObjectURL()` for object URLs created from `Blob` inputs; preserve existing status messages and caching when a blob is fetched successfully.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983d0e7ca7c83339e45ea7bfe2ebc71)