### PR TITLE
Add TTS base URL debug output near status

### DIFF
--- a/app.js
+++ b/app.js
@@ -521,6 +521,7 @@ function cacheElements() {
   els.next = document.getElementById('next-btn');
   els.playbackWarnings = document.getElementById('playback-warnings');
   els.status = document.getElementById('status');
+  els.ttsBaseUrlDebug = document.getElementById('tts-base-url-debug');
   els.transcript = document.getElementById('transcript');
   els.feedback = document.getElementById('feedback');
   els.customInput = document.getElementById('custom-sentence');
@@ -528,6 +529,19 @@ function cacheElements() {
   els.customReset = document.getElementById('custom-reset');
   els.customModal = document.getElementById('custom-modal');
   els.customDismissButtons = Array.from(document.querySelectorAll('[data-close-modal]'));
+
+  if (els.status && !els.ttsBaseUrlDebug) {
+    els.ttsBaseUrlDebug = document.createElement('div');
+    els.ttsBaseUrlDebug.id = 'tts-base-url-debug';
+    els.ttsBaseUrlDebug.className = 'status status-inline status-debug';
+    els.status.insertAdjacentElement('afterend', els.ttsBaseUrlDebug);
+  }
+
+  if (els.ttsBaseUrlDebug) {
+    const resolvedBaseUrl = getTtsBaseUrl();
+    els.ttsBaseUrlDebug.textContent = `TTS base URL: ${resolvedBaseUrl}`;
+    console.log('Resolved TTS base URL:', resolvedBaseUrl);
+  }
 }
 
 function createTooltips() {


### PR DESCRIPTION
### Motivation
- Provide a lightweight runtime confirmation of the resolved TTS base URL so it's easy to verify whether the `meta[name="tts-base-url"]` tag or a global (`window.TTS_BASE_URL` / `window.__TTS_BASE_URL__`) is being used by the app.

### Description
- In `cacheElements()` add `els.ttsBaseUrlDebug`, create a `div#tts-base-url-debug` (class `status status-inline status-debug`) if missing, insert it after the status element, set its text to the value returned by `getTtsBaseUrl()`, and also emit the resolved URL with `console.log`.

### Testing
- Served the app with `python -m http.server 8000` and used Playwright to open `index.html` and capture a screenshot (`artifacts/tts-base-url-debug.png`), which successfully loaded and shows the debug line with the resolved TTS base URL.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983d1a6a0b08333b3cbf6a7992f1ea5)