### PR TITLE
Fix Space playback toggle getting stuck after pause

### DIFF
--- a/app.js
+++ b/app.js
@@ -1867,8 +1867,15 @@ async function togglePlayback() {
 
   if (synth && synth.paused) {
     synth.resume();
-    setStatus('Playback resumed.');
-    return;
+
+    // Some engines can report paused/speaking inconsistently after resume.
+    // If resume does not actually continue playback, restart from the beginning
+    // instead of getting stuck in a paused state.
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    if (synth.speaking && !synth.paused) {
+      setStatus('Playback resumed.');
+      return;
+    }
   }
 
   await handlePlaybackClick(1);


### PR DESCRIPTION
### Motivation
- The global hotkey for Space (play/pause) could pause speech synthesis but then get stuck and not resume because some `speechSynthesis` engines report `paused`/`speaking` inconsistently after `resume()`.
- The change ensures toggle behavior reliably resumes playback or falls back to restarting playback instead of remaining in a paused deadlock.

### Description
- Updated `togglePlayback()` in `app.js` to add a verification step after calling `synth.resume()` that waits one animation frame via `requestAnimationFrame` and checks `synth.speaking && !synth.paused` before returning.
- If the synth does not actually resume, the function now falls back to calling `handlePlaybackClick(1)` to restart playback through the existing pipeline.
- Preserves existing audio-element pause/resume handling and status messages.

### Testing
- Ran `node --check app.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69983fd61df08333a025b6682103bec9)