### PR TITLE
Remove low-score retry feedback copy

### DIFF
--- a/app.js
+++ b/app.js
@@ -2915,7 +2915,7 @@ function finalizeScore(transcript) {
   } else if (score >= 50) {
     feedbackEl.textContent = `Good effort! Score: ${score}%. Try to fix the red words.`;
   } else {
-    feedbackEl.textContent = `Let's try again. Score: ${score}%. Focus on the first few words.`;
+    feedbackEl.textContent = `Score: ${score}%`;
   }
 
   saveProgress(score);


### PR DESCRIPTION
### Motivation
- Remove the discouraging and verbose coaching sentence shown for low scores and replace it with a neutral, concise score display.

### Description
- In `finalizeScore` within `app.js`, replaced the low-score feedback text `Let's try again. Score: ${score}%. Focus on the first few words.` with the concise `Score: ${score}%`.

### Testing
- Ran `node --test app.test.js`, which executed 9 tests with 8 passing and 1 failing (`keeps legitimate consecutive duplicates but trims extras`), and the failing test is unrelated to this copy-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b4ee75ffc8333abc5754b65ce9ab2)