### PR TITLE
Remove all score feedback text from finalizeScore

### DIFF
--- a/app.js
+++ b/app.js
@@ -2910,13 +2910,7 @@ function finalizeScore(transcript) {
   const feedbackEl = els.feedback;
   if (!feedbackEl) return;
 
-  if (score >= 80) {
-    feedbackEl.textContent = `Great! Score: ${score}%`;
-  } else if (score >= 50) {
-    feedbackEl.textContent = `Good effort! Score: ${score}%. Try to fix the red words.`;
-  } else {
-    feedbackEl.textContent = `Score: ${score}%`;
-  }
+  feedbackEl.textContent = '';
 
   saveProgress(score);
 }


### PR DESCRIPTION
### Motivation
- Remove all score-related feedback text from the UI so the feedback element stays empty after scoring.

### Description
- Replaced the conditional score messages in `finalizeScore` with a single assignment `feedbackEl.textContent = ''`, preserving the score calculation and `saveProgress(score)` call.

### Testing
- Ran `node --test app.test.js`, which produced 8 passing and 1 failing test; the failure is an existing, unrelated test (`keeps legitimate consecutive duplicates but trims extras`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b5327ce188333a02218df42bfb300)